### PR TITLE
Fix knockout table comment typo

### DIFF
--- a/db/schema.py
+++ b/db/schema.py
@@ -34,7 +34,7 @@ CREATE TABLE IF NOT EXISTS tournaments (
 )
 """
 
-# Таблица для хранения информации о накаутах
+# Таблица для хранения информации о нокаутах
 CREATE_KNOCKOUTS_TABLE = """
 CREATE TABLE IF NOT EXISTS knockouts (
     id INTEGER PRIMARY KEY AUTOINCREMENT,


### PR DESCRIPTION
## Summary
- fix Russian typo in comment before `CREATE_KNOCKOUTS_TABLE`

## Testing
- `python -m py_compile db/schema.py`
