### PR TITLE
Track knockouts per hand

### DIFF
--- a/db/repositories/knockout_repo.py
+++ b/db/repositories/knockout_repo.py
@@ -17,14 +17,25 @@ class KnockoutRepository:
         """
         with self.db.get_connection() as conn:
             c = conn.cursor()
-            c.execute("""
+            c.execute(
+                """
                 CREATE TABLE IF NOT EXISTS hero_knockouts (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
                     tournament_id TEXT NOT NULL,
                     hand_idx INTEGER NOT NULL,
-                    split BOOLEAN DEFAULT 0
+                    split BOOLEAN DEFAULT 0,
+                    UNIQUE(tournament_id, hand_idx)
                 )
-            """)
+                """
+            )
+            # Ensure unique index exists for old databases without the
+            # constraint defined in CREATE TABLE
+            c.execute(
+                """
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_hero_knockouts_unique
+                ON hero_knockouts(tournament_id, hand_idx)
+                """
+            )
             conn.commit()
 
     def add_knockout(self, tournament_id, hand_idx, split=False):
@@ -33,10 +44,13 @@ class KnockoutRepository:
         """
         with self.db.get_connection() as conn:
             c = conn.cursor()
-            c.execute("""
-                INSERT INTO hero_knockouts (tournament_id, hand_idx, split)
+            c.execute(
+                """
+                INSERT OR IGNORE INTO hero_knockouts (tournament_id, hand_idx, split)
                 VALUES (?, ?, ?)
-            """, (tournament_id, hand_idx, int(split)))
+                """,
+                (tournament_id, hand_idx, int(split)),
+            )
             conn.commit()
 
     def get_hero_knockouts(self, tournament_id=None):

--- a/tests/test_knockout_repository.py
+++ b/tests/test_knockout_repository.py
@@ -1,0 +1,28 @@
+import os
+import tempfile
+import unittest
+
+from db.database import DatabaseManager
+from db.repositories.knockout_repo import KnockoutRepository
+
+class TestKnockoutRepository(unittest.TestCase):
+    def setUp(self):
+        fd, self.db_path = tempfile.mkstemp()
+        os.close(fd)
+        self.manager = DatabaseManager(self.db_path)
+        self.repo = KnockoutRepository(self.manager)
+
+    def tearDown(self):
+        try:
+            os.remove(self.db_path)
+        except OSError:
+            pass
+
+    def test_insert_ignore_duplicates(self):
+        self.repo.add_knockout("T1", 1)
+        self.repo.add_knockout("T1", 1)  # duplicate should be ignored
+        kos = self.repo.get_hero_knockouts("T1")
+        self.assertEqual(len(kos), 1)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -518,6 +518,17 @@ class MainWindow(QtWidgets.QMainWindow):
                             continue
                     
                     current_tournament_id = parsed_tournament_id
+
+                    # Record individual knockouts for statistics
+                    for hand in res.get("hands", []):
+                        hero_ko = hand.get("hero_ko", 0)
+                        hand_idx = hand.get("hand_idx")
+                        if hero_ko and hand_idx is not None:
+                            for _ in range(hero_ko):
+                                self.knockout_repo.add_knockout(
+                                    parsed_tournament_id,
+                                    hand_idx,
+                                )
                     
                     existing = self.tournament_repo.get_hero_tournament(current_tournament_id) if hasattr(self.tournament_repo, "get_hero_tournament") else None
                     self.tournament_repo.add_or_update_tournament(


### PR DESCRIPTION
## Summary
- add UNIQUE constraint to hero_knockouts table
- ignore duplicate inserts into hero_knockouts
- record knockouts from parsed HH files
- test knockout repository behaviour

## Testing
- `python -m unittest discover -s tests -v`