### PR TITLE
Add parser tests and verify _parse_files skipping

### DIFF
--- a/tests/test_parse_files_skip.py
+++ b/tests/test_parse_files_skip.py
@@ -1,0 +1,130 @@
+import os
+import sys
+import tempfile
+import types
+import importlib
+import unittest
+from unittest.mock import patch
+
+
+def load_main_window_with_stubs():
+    qtw = types.SimpleNamespace()
+    class Dummy:
+        def __init__(self, *a, **k):
+            pass
+        def setWindowModality(self, *a, **k):
+            pass
+        def setMinimumDuration(self, *a, **k):
+            pass
+        def setMaximum(self, *a, **k):
+            pass
+        def wasCanceled(self):
+            return False
+        def setLabelText(self, *a, **k):
+            pass
+        def setValue(self, *a, **k):
+            pass
+        def close(self):
+            pass
+
+    for name in [
+        'QProgressDialog', 'QDialog', 'QWidget', 'QVBoxLayout',
+        'QListWidget', 'QLabel', 'QPushButton', 'QHBoxLayout', 'QLineEdit',
+        'QListWidgetItem', 'QMessageBox', 'QMainWindow', 'QStatusBar',
+        'QToolBar', 'QTabWidget', 'QFileDialog', 'QInputDialog'
+    ]:
+        setattr(qtw, name, type(name, (Dummy,), {}))
+
+    class QApplication(Dummy):
+        @staticmethod
+        def processEvents(*a, **k):
+            pass
+
+    qtw.QApplication = QApplication
+    qtcore = types.SimpleNamespace(
+        Qt=types.SimpleNamespace(WindowModality=types.SimpleNamespace(WindowModal=1)),
+        QSize=type('QSize', (), {})
+    )
+    qtgui = types.SimpleNamespace(QIcon=type('QIcon', (), {}))
+    qtmod = types.ModuleType('PyQt6')
+    qtmod.QtWidgets = qtw
+    qtmod.QtGui = qtgui
+    qtmod.QtCore = qtcore
+    sys.modules['PyQt6'] = qtmod
+    sys.modules['PyQt6.QtWidgets'] = qtw
+    sys.modules['PyQt6.QtGui'] = qtgui
+    sys.modules['PyQt6.QtCore'] = qtcore
+
+    app_style = types.ModuleType('ui.app_style')
+    app_style.apply_dark_theme = lambda *a, **k: None
+    sys.modules['ui.app_style'] = app_style
+
+    config = types.ModuleType('config')
+    config.APP_TITLE = 'test'
+    config.DB_PATH = 'db'
+    config.MIN_FINAL_TABLE_BLIND = 50
+    config.HERO_NAME = 'Hero'
+    sys.modules['config'] = config
+
+    sys.modules['db.database'] = types.ModuleType('db.database')
+    sys.modules['db.database'].DatabaseManager = type('DB', (), {})
+    repo_mod = types.ModuleType('db.repositories')
+    class Repo:
+        pass
+    repo_mod.TournamentRepository = Repo
+    repo_mod.KnockoutRepository = Repo
+    repo_mod.SessionRepository = Repo
+    repo_mod.StatsRepository = Repo
+    sys.modules['db.repositories'] = repo_mod
+
+    for name in ['ui.stats_grid', 'ui.tournament_view', 'ui.knockout_table', 'ui.session_view']:
+        mod = types.ModuleType(name)
+        setattr(mod, name.split('.')[-1].title().replace('_', ''), type('X', (), {}))
+        sys.modules[name] = mod
+
+    return importlib.import_module('ui.main_window')
+
+
+class TestParseFilesSkip(unittest.TestCase):
+    def test_skips_files_without_id(self):
+        mw_mod = load_main_window_with_stubs()
+        MainWindow = mw_mod.MainWindow
+        mw = MainWindow.__new__(MainWindow)
+
+        class DummyRepo:
+            def __init__(self):
+                self.ids = []
+            def get_hero_tournament(self, *a, **k):
+                return {}
+            def add_or_update_tournament(self, tournament_id, **kwargs):
+                self.ids.append(tournament_id)
+        mw.tournament_repo = DummyRepo()
+        mw.refresh_all_data = lambda: None
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hh_missing = os.path.join(tmpdir, 'hh_missing.txt')
+            with open(hh_missing, 'w') as f:
+                f.write('Poker Hand #1\nNo tid')
+            summary_missing = os.path.join(tmpdir, 'summary_missing.txt')
+            with open(summary_missing, 'w') as f:
+                f.write('No id here')
+            hh_ok = os.path.join(tmpdir, 'hh_ok.txt')
+            with open(hh_ok, 'w') as f:
+                f.write('Poker Hand #2\n')
+
+            with patch.object(mw_mod, 'HandHistoryParser') as hh_cls, \
+                 patch.object(mw_mod, 'TournamentSummaryParser') as sum_cls:
+                hh_instance = hh_cls.return_value
+                hh_instance.parse.side_effect = [
+                    {'tournament_id': None, 'hero_ko_count': 0},
+                    {'tournament_id': '333', 'hero_ko_count': 0}
+                ]
+                sum_cls.return_value.parse.return_value = {'tournament_id': None}
+
+                mw._parse_files([hh_missing, summary_missing, hh_ok])
+
+        self.assertEqual(mw.tournament_repo.ids, ['333'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_parser_tournament_id_examples.py
+++ b/tests/test_parser_tournament_id_examples.py
@@ -1,0 +1,24 @@
+import os
+import unittest
+from parsers.hand_history import HandHistoryParser
+from parsers.tournament_summary import TournamentSummaryParser
+
+
+class TestTournamentIDExamples(unittest.TestCase):
+    def test_hand_history_example_has_correct_id(self):
+        path = os.path.join('hh_examples', 'GG20250515-2149 - 11 - 0.4 - 0.8 - 9max.txt')
+        with open(path, 'r', encoding='utf-8') as f:
+            content = f.read()
+        result = HandHistoryParser().parse(content)
+        self.assertEqual(result['tournament_id'], '206997317')
+
+    def test_summary_example_has_correct_id(self):
+        path = os.path.join('hh_examples', 'GG20250515 - Tournament #206881959 - Mystery Battle Royale 10.txt')
+        with open(path, 'r', encoding='utf-8') as f:
+            content = f.read()
+        result = TournamentSummaryParser().parse(content, filename=os.path.basename(path))
+        self.assertEqual(result['tournament_id'], '206881959')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add sample-based tournament ID tests for both parsers
- add test ensuring `_parse_files` ignores files without an ID

## Testing
- `python -m unittest discover -s tests`