### PR TITLE
Update elimination logic in HH parser

### DIFF
--- a/parsers/tournament_summary.py
+++ b/parsers/tournament_summary.py
@@ -138,11 +138,10 @@ class TournamentSummaryParser(BaseParser):
 
         result = {
             "tournament_id": tournament_id,
-            "tournament_name": tournament_name,
-            "start_time": start_time,
-            "buyin": buyin,
+            "place": finish_place,
             "payout": payout,
-            "finish_place": finish_place,
+            "buyin": buyin,
+            "date": start_time,
         }
 
         logger.debug(f"Парсинг TS завершен для {tournament_id}. Данные: {result}")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,11 @@
+
+# During discovery unittest may try to import the real `ui` package which
+# requires PyQt6. Provide a lightweight stub package so that import succeeds.
+import sys
+import types
+import os
+
+if 'ui' not in sys.modules:
+    stub = types.ModuleType('ui')
+    stub.__path__ = [os.path.join(os.path.dirname(__file__), '..', 'ui')]
+    sys.modules['ui'] = stub


### PR DESCRIPTION
## Summary
- compute player elimination directly from final stack in `HandHistoryParser`
- adjust `TournamentSummaryParser` output keys
- fix tests and PyQt stubs to run without real UI

## Testing
- `python3 -m unittest discover -v`