### PR TITLE
Add early final table bust statistics

### DIFF
--- a/application_service.py
+++ b/application_service.py
@@ -36,6 +36,7 @@ from stats import (
     FinalTableReachStat, # Новый
     AvgFTInitialStackStat, # Новый
     EarlyFTKOStat, # Новый
+    EarlyFTBustStat,
     AvgFinishPlaceStat,
     AvgFinishPlaceFTStat,
     AvgFinishPlaceNoFTStat,
@@ -55,6 +56,7 @@ STAT_PLUGINS: List[BaseStat] = [
     FinalTableReachStat(),
     AvgFTInitialStackStat(),
     EarlyFTKOStat(),
+    EarlyFTBustStat(),
     AvgFinishPlaceStat(),
     AvgFinishPlaceFTStat(),
     AvgFinishPlaceNoFTStat(),
@@ -678,6 +680,16 @@ class ApplicationService:
         # Среднее KO в ранней финалке на турнир (считаем только для турниров, достигших финалки)
         stats.early_ft_ko_per_tournament = stats.early_ft_ko_count / stats.total_final_tables if stats.total_final_tables > 0 else 0.0
 
+        # Вылеты Hero на ранней стадии финалки (6-9 место)
+        stats.early_ft_bust_count = sum(
+            1
+            for t in final_table_tournaments
+            if t.finish_place is not None and 6 <= t.finish_place <= 9
+        )
+        stats.early_ft_bust_per_tournament = (
+            stats.early_ft_bust_count / stats.total_final_tables if stats.total_final_tables > 0 else 0.0
+        )
+
         # Логируем статистику по выплатам для отладки
         tournaments_with_payout = sum(1 for t in all_tournaments if t.payout is not None and t.payout > 0)
         tournaments_without_payout = sum(1 for t in all_tournaments if t.payout is None or t.payout == 0)
@@ -718,6 +730,7 @@ class ApplicationService:
         stats.avg_ft_initial_stack_chips = round(stats.avg_ft_initial_stack_chips, 2)
         stats.avg_ft_initial_stack_bb = round(stats.avg_ft_initial_stack_bb, 2)
         stats.early_ft_ko_per_tournament = round(stats.early_ft_ko_per_tournament, 2)
+        stats.early_ft_bust_per_tournament = round(stats.early_ft_bust_per_tournament, 2)
         stats.final_table_reach_percent = round(stats.final_table_reach_percent, 2)
 
         logger.info(f"Итоговая статистика: tournaments={stats.total_tournaments}, knockouts={stats.total_knockouts}, prize={stats.total_prize}, buyin={stats.total_buy_in}")

--- a/db/repositories/overall_stats_repo.py
+++ b/db/repositories/overall_stats_repo.py
@@ -60,6 +60,8 @@ class OverallStatsRepository:
                 big_ko_x10000 = ?,
                 early_ft_ko_count = ?,
                 early_ft_ko_per_tournament = ?,
+                early_ft_bust_count = ?,
+                early_ft_bust_per_tournament = ?,
                 last_updated = ?
             WHERE id = 1
         """
@@ -83,6 +85,8 @@ class OverallStatsRepository:
             stats.big_ko_x10000,
             stats.early_ft_ko_count,
             stats.early_ft_ko_per_tournament,
+            stats.early_ft_bust_count,
+            stats.early_ft_bust_per_tournament,
             datetime.now().isoformat(), # Обновляем метку времени
         )
         self.db.execute_update(query, params)

--- a/db/schema.py
+++ b/db/schema.py
@@ -82,6 +82,8 @@ CREATE TABLE IF NOT EXISTS overall_stats (
     big_ko_x10000 INTEGER DEFAULT 0,
     early_ft_ko_count INTEGER DEFAULT 0,
     early_ft_ko_per_tournament REAL DEFAULT 0,
+    early_ft_bust_count INTEGER DEFAULT 0,
+    early_ft_bust_per_tournament REAL DEFAULT 0,
     last_updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 )
 """
@@ -189,6 +191,8 @@ UPDATE overall_stats SET
     big_ko_x10000 = ?,
     early_ft_ko_count = ?,
     early_ft_ko_per_tournament = ?,
+    early_ft_bust_count = ?,
+    early_ft_bust_per_tournament = ?,
     last_updated = CURRENT_TIMESTAMP
 WHERE id = 1
 """

--- a/models/overall_stats.py
+++ b/models/overall_stats.py
@@ -34,6 +34,8 @@ class OverallStats:
     big_ko_x10000: int = 0
     early_ft_ko_count: int = 0 # Общее KO в ранней стадии финалки (9-6 игроков)
     early_ft_ko_per_tournament: float = 0.0 # Среднее KO в ранней финалке на турнир (достигший финалки)
+    early_ft_bust_count: int = 0  # Количество вылетов Hero на местах 6-9
+    early_ft_bust_per_tournament: float = 0.0  # Среднее число таких вылетов на турнир с финалкой
     last_updated: Optional[str] = None
     id: Optional[int] = 1 # ID из БД, всегда 1
 
@@ -61,6 +63,8 @@ class OverallStats:
             "big_ko_x10000": self.big_ko_x10000,
             "early_ft_ko_count": self.early_ft_ko_count,
             "early_ft_ko_per_tournament": self.early_ft_ko_per_tournament,
+            "early_ft_bust_count": self.early_ft_bust_count,
+            "early_ft_bust_per_tournament": self.early_ft_bust_per_tournament,
             "last_updated": self.last_updated,
             "id": self.id,
         }
@@ -95,6 +99,8 @@ class OverallStats:
                     big_ko_x10000=data.get("big_ko_x10000", 0),
                     early_ft_ko_count=data.get("early_ft_ko_count", 0),
                     early_ft_ko_per_tournament=data.get("early_ft_ko_per_tournament", 0.0),
+                    early_ft_bust_count=data.get("early_ft_bust_count", 0),
+                    early_ft_bust_per_tournament=data.get("early_ft_bust_per_tournament", 0.0),
                     last_updated=data.get("last_updated"),
                     id=data.get("id", 1)
                 )
@@ -120,6 +126,8 @@ class OverallStats:
                     big_ko_x10000=data["big_ko_x10000"] if "big_ko_x10000" in data.keys() else 0,
                     early_ft_ko_count=data["early_ft_ko_count"] if "early_ft_ko_count" in data.keys() else 0,
                     early_ft_ko_per_tournament=data["early_ft_ko_per_tournament"] if "early_ft_ko_per_tournament" in data.keys() else 0.0,
+                    early_ft_bust_count=data["early_ft_bust_count"] if "early_ft_bust_count" in data.keys() else 0,
+                    early_ft_bust_per_tournament=data["early_ft_bust_per_tournament"] if "early_ft_bust_per_tournament" in data.keys() else 0.0,
                     last_updated=data["last_updated"] if "last_updated" in data.keys() else None,
                     id=data["id"] if "id" in data.keys() else 1
                 )

--- a/stats/early_ft_bust.py
+++ b/stats/early_ft_bust.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+"""
+Плагин для подсчёта количества вылетов Hero на ранней стадии финального стола
+(места 6-9) и среднего их числа на турнир с финалкой.
+"""
+from typing import Dict, Any, List
+from .base import BaseStat
+from models import Tournament, OverallStats
+
+
+class EarlyFTBustStat(BaseStat):
+    """Статистика вылетов в ранней стадии финального стола."""
+
+    name: str = "Early FT Busts"
+    description: str = (
+        "Количество вылетов Hero на ранней стадии финального стола (6-9 место)"
+    )
+
+    def compute(
+        self,
+        tournaments: List[Tournament],
+        final_table_hands: List[Any],
+        sessions: List[Any],
+        overall_stats: OverallStats,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Рассчитывает количество вылетов и среднее число таких вылетов."""
+        if not tournaments and not overall_stats:
+            return {"early_ft_bust_count": 0, "early_ft_bust_per_tournament": 0.0}
+
+        if overall_stats and hasattr(overall_stats, "early_ft_bust_count") and hasattr(
+            overall_stats, "early_ft_bust_per_tournament"
+        ):
+            bust_count = overall_stats.early_ft_bust_count
+            bust_per_tournament = overall_stats.early_ft_bust_per_tournament
+        else:
+            ft_tournaments = [t for t in tournaments if t.reached_final_table]
+            bust_count = sum(
+                1
+                for t in ft_tournaments
+                if t.finish_place is not None and 6 <= t.finish_place <= 9
+            )
+            total_final_tables = len(ft_tournaments)
+            bust_per_tournament = (
+                bust_count / total_final_tables if total_final_tables > 0 else 0.0
+            )
+
+        return {
+            "early_ft_bust_count": bust_count,
+            "early_ft_bust_per_tournament": round(bust_per_tournament, 2),
+        }

--- a/ui/stats_grid.py
+++ b/ui/stats_grid.py
@@ -27,6 +27,7 @@ from stats import (
     FinalTableReachStat,
     AvgFTInitialStackStat,
     EarlyFTKOStat,
+    EarlyFTBustStat,
     AvgFinishPlaceStat,
     AvgFinishPlaceFTStat,
     AvgFinishPlaceNoFTStat,
@@ -233,6 +234,7 @@ class StatsGrid(QtWidgets.QWidget):
             'ft_reach': StatCard("% Достижения FT", "-"),
             'avg_ft_stack': SpecialStatCard("Средний стек на FT", "-"),
             'early_ft_ko': SpecialStatCard("KO в ранней FT", "-"),
+            'early_ft_bust': SpecialStatCard("Вылеты ранней FT", "-"),
             'avg_place_all': StatCard("Среднее место (все)", "-"),
             'avg_place_ft': StatCard("Среднее место (FT)", "-"),
             'avg_place_no_ft': StatCard("Среднее место (не FT)", "-"),
@@ -243,7 +245,7 @@ class StatsGrid(QtWidgets.QWidget):
         positions = [
             ('tournaments', 0, 0), ('knockouts', 0, 1), ('avg_ko', 0, 2), ('roi', 0, 3),
             ('itm', 1, 0), ('ft_reach', 1, 1), ('avg_ft_stack', 1, 2), ('early_ft_ko', 1, 3),
-            ('avg_place_all', 2, 0), ('avg_place_ft', 2, 1), ('avg_place_no_ft', 2, 2), ('avg_place_empty', 2, 3),
+            ('avg_place_all', 2, 0), ('avg_place_ft', 2, 1), ('avg_place_no_ft', 2, 2), ('early_ft_bust', 2, 3),
         ]
         
         for key, row, col in positions:
@@ -477,6 +479,16 @@ class StatsGrid(QtWidgets.QWidget):
                 f"{early_ko_per:.2f} за турнир с FT"
             )
             logger.debug(f"Обновлена карточка early_ft_ko: {early_ko_count} / {early_ko_per:.2f}")
+
+            bust_result = EarlyFTBustStat().compute(all_tournaments, [], [], overall_stats)
+            logger.debug(f"Early FT Bust result: {bust_result}")
+            bust_count = bust_result.get('early_ft_bust_count', 0)
+            bust_per = bust_result.get('early_ft_bust_per_tournament', 0.0)
+            self.cards['early_ft_bust'].update_value(
+                str(bust_count),
+                f"{bust_per:.2f} за турнир с FT"
+            )
+            logger.debug(f"Обновлена карточка early_ft_bust: {bust_count} / {bust_per:.2f}")
             
             self.bigko_cards['x1.5'].update_value(str(overall_stats.big_ko_x1_5))
             self.bigko_cards['x2'].update_value(str(overall_stats.big_ko_x2))


### PR DESCRIPTION
## Summary
- add EarlyFTBustStat plugin
- store bust stats in OverallStats model and database schema
- compute early final table busts in ApplicationService
- display new bust stat card in StatsGrid UI

## Testing
- `pytest -q` *(fails: AttributeError: module 'config' has no attribute 'DEBUG')*