### PR TITLE
Add color logic for x10 big KO stat

### DIFF
--- a/ui/app_style.py
+++ b/ui/app_style.py
@@ -301,6 +301,32 @@ def apply_cell_color_by_value(widget_or_item, value: Optional[float]):
         widget_or_item.setStyleSheet(f"color: {color};")
 
 
+def apply_bigko_x10_color(label: QtWidgets.QLabel, total_tournaments: int, x10_count: int):
+    """Applies color to the x10 Big KO label based on average frequency."""
+    if not isinstance(label, QtWidgets.QLabel):
+        return
+
+    # Default color is gray if we cannot compute frequency
+    color = "#A1A1AA"
+
+    if x10_count <= 0 or total_tournaments <= 0:
+        color = "#EF4444"  # Red when there were no x10 knockouts
+    else:
+        avg_interval = total_tournaments / x10_count
+
+        if avg_interval <= 51:
+            # Gold color when very frequent
+            color = "#FFD700"
+        elif 52 <= avg_interval <= 58:
+            color = "#10B981"  # Green
+        elif 59 <= avg_interval <= 65:
+            color = "#F59E0B"  # Orange
+        elif avg_interval > 65:
+            color = "#EF4444"  # Red
+
+    label.setStyleSheet(f"color: {color}; font-weight: bold;")
+
+
 def create_separator() -> QtWidgets.QFrame:
     """Создает горизонтальный разделитель."""
     separator = QtWidgets.QFrame()

--- a/ui/stats_grid.py
+++ b/ui/stats_grid.py
@@ -15,7 +15,12 @@ from application_service import ApplicationService
 from models import OverallStats
 
 # Импортируем функции стилизации
-from ui.app_style import format_money, format_percentage, apply_cell_color_by_value
+from ui.app_style import (
+    format_money,
+    format_percentage,
+    apply_cell_color_by_value,
+    apply_bigko_x10_color,
+)
 
 # Импортируем плагины для получения их результатов
 from stats import (
@@ -484,6 +489,11 @@ class StatsGrid(QtWidgets.QWidget):
             self.bigko_cards['x100'].update_value(str(overall_stats.big_ko_x100))
             self.bigko_cards['x1000'].update_value(str(overall_stats.big_ko_x1000))
             self.bigko_cards['x10000'].update_value(str(overall_stats.big_ko_x10000))
+            apply_bigko_x10_color(
+                self.bigko_cards['x10'].value_label,
+                overall_stats.total_tournaments,
+                overall_stats.big_ko_x10,
+            )
             logger.debug(f"Обновлены карточки Big KO: x1.5={overall_stats.big_ko_x1_5}, x2={overall_stats.big_ko_x2}, x10={overall_stats.big_ko_x10}, x100={overall_stats.big_ko_x100}, x1000={overall_stats.big_ko_x1000}, x10000={overall_stats.big_ko_x10000}")
             
             # Статы средних мест (fallback расчет, пока не обновлены другие компоненты)


### PR DESCRIPTION
## Summary
- support color coding for the x10 Big KO stat card
- show red/orange/green/gold based on how often Hero gets an x10 KO

## Testing
- `python -m unittest discover tests` *(fails: AttributeError: module 'config' has no attribute 'DEBUG')*