### PR TITLE
Implement bright green highlight for high-tier Big KO cards

### DIFF
--- a/ui/app_style.py
+++ b/ui/app_style.py
@@ -328,6 +328,20 @@ def apply_bigko_x10_color(label: QtWidgets.QLabel, total_tournaments: int, x10_c
     label.setStyleSheet(f"color: {color}; font-weight: bold;")
 
 
+def apply_bigko_high_tier_color(label: QtWidgets.QLabel, count: int):
+    """Applies bright green color and fire emoji for high tier Big KO counts."""
+    if not isinstance(label, QtWidgets.QLabel):
+        return
+
+    if count > 0:
+        color = "#00FF00"  # Bright green
+        label.setText(f"{label.text()} \U0001F525")
+    else:
+        color = "#EF4444"  # Red when there were none
+
+    label.setStyleSheet(f"color: {color}; font-weight: bold;")
+
+
 def create_separator() -> QtWidgets.QFrame:
     """Создает горизонтальный разделитель."""
     separator = QtWidgets.QFrame()

--- a/ui/stats_grid.py
+++ b/ui/stats_grid.py
@@ -20,6 +20,7 @@ from ui.app_style import (
     format_percentage,
     apply_cell_color_by_value,
     apply_bigko_x10_color,
+    apply_bigko_high_tier_color,
 )
 
 # Импортируем плагины для получения их результатов
@@ -506,6 +507,18 @@ class StatsGrid(QtWidgets.QWidget):
                 self.bigko_cards['x10'].value_label,
                 overall_stats.total_tournaments,
                 overall_stats.big_ko_x10,
+            )
+            apply_bigko_high_tier_color(
+                self.bigko_cards['x100'].value_label,
+                overall_stats.big_ko_x100,
+            )
+            apply_bigko_high_tier_color(
+                self.bigko_cards['x1000'].value_label,
+                overall_stats.big_ko_x1000,
+            )
+            apply_bigko_high_tier_color(
+                self.bigko_cards['x10000'].value_label,
+                overall_stats.big_ko_x10000,
             )
             logger.debug(f"Обновлены карточки Big KO: x1.5={overall_stats.big_ko_x1_5}, x2={overall_stats.big_ko_x2}, x10={overall_stats.big_ko_x10}, x100={overall_stats.big_ko_x100}, x1000={overall_stats.big_ko_x1000}, x10000={overall_stats.big_ko_x10000}")
             


### PR DESCRIPTION
## Summary
- add `apply_bigko_high_tier_color` helper
- highlight x100/x1000/x10000 KO counts in bright green with fire emoji when positive

## Testing
- `pytest -q` *(fails: AttributeError: module 'config' has no attribute 'DEBUG', FileNotFoundError, AssertionError)*