### PR TITLE
Fix DB list refresh and remember last DB

### DIFF
--- a/application_service.py
+++ b/application_service.py
@@ -156,7 +156,13 @@ class ApplicationService:
             # Можно вернуть False или пробросить исключение, чтобы UI показал ошибку
             raise FileExistsError(f"База данных '{os.path.basename(new_db_path)}' уже существует.")
 
-        self.db.set_db_path(new_db_path) # Set path will also attempt init
+        self.db.set_db_path(new_db_path)  # Устанавливаем новый путь
+
+        # Принудительно открываем соединение, чтобы физически создать файл БД
+        # и инициализировать схему. Иначе файл появится только при первом
+        # обращении к данным, что мешает отображению новой БД в диалоге.
+        conn = self.db.get_connection()
+        self.db.close_connection()
 
         logger.info(f"Создана и выбрана новая база данных: {new_db_path}")
 

--- a/config.py
+++ b/config.py
@@ -18,8 +18,18 @@ os.makedirs(DEFAULT_DB_DIR, exist_ok=True)
 DEFAULT_DB_NAME = "royal_stats.db"
 DB_PATH = os.path.join(DEFAULT_DB_DIR, DEFAULT_DB_NAME)
 
+# Файл для хранения последней выбранной БД
+LAST_DB_FILE = os.path.join(DEFAULT_DB_DIR, "last_db_path.txt")
+
 # Последняя открытая БД
-LAST_DB_PATH = DB_PATH # Значение по умолчанию
+if os.path.exists(LAST_DB_FILE):
+    try:
+        with open(LAST_DB_FILE, "r", encoding="utf-8") as f:
+            LAST_DB_PATH = f.read().strip() or DB_PATH
+    except Exception:
+        LAST_DB_PATH = DB_PATH
+else:
+    LAST_DB_PATH = DB_PATH
 
 # ==== Настройки игры ====
 # Параметры для определения финального стола и "зоны KO" в HH
@@ -44,4 +54,9 @@ def set_db_path(path: str) -> None:
     global DB_PATH, LAST_DB_PATH
     DB_PATH = path
     LAST_DB_PATH = path
+    try:
+        with open(LAST_DB_FILE, "w", encoding="utf-8") as f:
+            f.write(path)
+    except Exception:
+        pass
 


### PR DESCRIPTION
## Summary
- when creating a new database, force connection creation so the file exists
- save last opened database path to a file and read it on startup

## Testing
- `python -m py_compile $(git ls-files '*.py')`