### PR TITLE
Improve progress bar flow

### DIFF
--- a/application_service.py
+++ b/application_service.py
@@ -173,6 +173,10 @@ class ApplicationService:
         """
         logger.info(f"=== НАЧАЛО ИМПОРТА ===")
         logger.info(f"is_canceled_callback передан: {is_canceled_callback is not None}")
+
+        # Показываем прогресс на этапе предварительной подготовки
+        if progress_callback:
+            progress_callback(0, 100, "Подготовка файлов...")
         
         all_files_to_process = []
         filtered_files_count = 0

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -260,30 +260,16 @@ class MainWindow(QtWidgets.QMainWindow):
         logger.info("Поток импорта завершен.")
         # progress_dialog закроется автоматически если autoClose=True
         
-        # Запускаем асинхронное обновление статистики
-        self.statusBar().showMessage("Обновление статистики...")
-        
-        # Создаем и запускаем поток обновления статистики после импорта
-        self.post_import_refresh_thread = RefreshThread(self.app_service)
-        self.post_import_refresh_thread.progress_update.connect(self._on_refresh_progress)
-        self.post_import_refresh_thread.progress_percent.connect(self._on_refresh_percent)
-        self.post_import_refresh_thread.finished_update.connect(self._on_post_import_refresh_finished)
-        self.post_import_refresh_thread.error_occurred.connect(self._on_refresh_error)
-        self.post_import_refresh_thread.start()
-
-    @QtCore.pyqtSlot()
-    def _on_post_import_refresh_finished(self):
-        """Вызывается по завершении обновления статистики после импорта."""
-        logger.info("Обновление статистики после импорта завершено")
-        
-        # Обновляем UI компоненты в основном потоке
+        # По завершении импорта сразу обновляем UI
         self._update_toolbar_info()
-        
-        # Инвалидируем кеш и обновляем вкладки
         self.invalidate_all_caches()
-        self.refresh_all_views()
-        
-        self.statusBar().showMessage(f"Импорт завершен. База данных: {os.path.basename(self.app_service.db_path)}", 3000)
+        self.refresh_all_views(show_overlay=False)
+
+        self.statusBar().showMessage(
+            f"Импорт завершен. База данных: {os.path.basename(self.app_service.db_path)}",
+            3000,
+        )
+
 
     def invalidate_all_caches(self):
         """Инвалидирует кеш данных во всех view компонентах."""
@@ -294,14 +280,14 @@ class MainWindow(QtWidgets.QMainWindow):
         if hasattr(self, 'session_view') and self.session_view:
             self.session_view.invalidate_cache()
 
-    def refresh_all_views(self):
+    def refresh_all_views(self, show_overlay: bool = True):
         """Обновляет все view компоненты."""
         if hasattr(self, 'stats_grid') and self.stats_grid:
-            self.stats_grid.reload()
+            self.stats_grid.reload(show_overlay=show_overlay)
         if hasattr(self, 'tournament_view') and self.tournament_view:
-            self.tournament_view.reload()
+            self.tournament_view.reload(show_overlay=show_overlay)
         if hasattr(self, 'session_view') and self.session_view:
-            self.session_view.reload()
+            self.session_view.reload(show_overlay=show_overlay)
 
     def refresh_all_data(self):
         """

--- a/ui/session_view.py
+++ b/ui/session_view.py
@@ -195,12 +195,13 @@ class SessionView(QtWidgets.QWidget):
         self._cache_valid = False
         self._data_cache.clear()
         
-    def reload(self):
+    def reload(self, show_overlay: bool = True):
         """Перезагружает данные из ApplicationService."""
         logger.debug("Перезагрузка SessionView...")
-        
-        # Показываем индикатор загрузки
-        self.show_loading_overlay()
+
+        self._show_overlay = show_overlay
+        if show_overlay:
+            self.show_loading_overlay()
         
         self._reload_thread = SessionViewReloadThread(self.app_service)
         self._reload_thread.data_loaded.connect(self._on_data_loaded)
@@ -214,7 +215,8 @@ class SessionView(QtWidgets.QWidget):
             self._update_sessions_table()
             logger.debug("Перезагрузка SessionView завершена.")
         finally:
-            self.hide_loading_overlay()
+            if getattr(self, "_show_overlay", False):
+                self.hide_loading_overlay()
             
     def _load_data(self):
         """Загружает данные из ApplicationService в кеш."""

--- a/ui/stats_grid.py
+++ b/ui/stats_grid.py
@@ -427,12 +427,14 @@ class StatsGrid(QtWidgets.QWidget):
         self._cache_valid = False
         self._data_cache.clear()
         
-    def reload(self):
+    def reload(self, show_overlay: bool = True):
         """Перезагружает все данные из ApplicationService."""
         logger.debug("=== Начало reload StatsGrid ===")
 
-        # Показываем индикатор загрузки
-        self.show_loading_overlay()
+        # Показываем индикатор загрузки, если требуется
+        self._show_overlay = show_overlay
+        if show_overlay:
+            self.show_loading_overlay()
 
         self._reload_thread = StatsGridReloadThread(self.app_service)
         self._reload_thread.data_loaded.connect(self._on_data_loaded)
@@ -534,7 +536,8 @@ class StatsGrid(QtWidgets.QWidget):
         
         finally:
             # Скрываем индикатор загрузки
-            self.hide_loading_overlay()
+            if getattr(self, "_show_overlay", False):
+                self.hide_loading_overlay()
         
     def _update_chart(self, place_dist=None):
         """Обновляет гистограмму распределения мест."""

--- a/ui/tournament_view.py
+++ b/ui/tournament_view.py
@@ -194,12 +194,14 @@ class TournamentView(QtWidgets.QWidget):
         self._cache_valid = False
         self._data_cache.clear()
         
-    def reload(self):
+    def reload(self, show_overlay: bool = True):
         """Перезагружает данные из ApplicationService."""
         logger.debug("Перезагрузка TournamentView...")
-        
-        # Показываем индикатор загрузки
-        self.show_loading_overlay()
+
+        self._show_overlay = show_overlay
+        # Показываем индикатор загрузки при необходимости
+        if show_overlay:
+            self.show_loading_overlay()
         
         self._reload_thread = TournamentViewReloadThread(self.app_service)
         self._reload_thread.data_loaded.connect(self._on_data_loaded)
@@ -218,7 +220,8 @@ class TournamentView(QtWidgets.QWidget):
 
             logger.debug("Перезагрузка TournamentView завершена.")
         finally:
-            self.hide_loading_overlay()
+            if getattr(self, "_show_overlay", False):
+                self.hide_loading_overlay()
             
     def _load_data(self):
         """Загружает данные из ApplicationService в кеш."""


### PR DESCRIPTION
## Summary
- call progress callback early when preparing files
- update UI after import without extra threads
- allow silent reload of views
- hide loading overlays when not needed

## Testing
- `python -m py_compile ui/main_window.py ui/stats_grid.py ui/session_view.py ui/tournament_view.py application_service.py`
- `pytest -q` *(fails: module 'config' has no attribute 'DEBUG')*