### PR TITLE
Fix big KO card color

### DIFF
--- a/ui/app_style.py
+++ b/ui/app_style.py
@@ -343,7 +343,8 @@ def apply_bigko_high_tier_color(label: QtWidgets.QLabel, count: int):
         color = "#00FF00"  # Bright green
         label.setText(f"{label.text()} \U0001F525")
     else:
-        color = "#EF4444"  # Red when there were none
+        # Return default white color for zero values
+        color = "#FAFAFA"
 
     label.setStyleSheet(f"color: {color}; font-weight: bold;")
 


### PR DESCRIPTION
## Summary
- apply default white text for Big KO high-tier stats when value is 0

## Testing
- `pytest -q` *(fails: AttributeError: module 'config' has no attribute 'DEBUG')*