### PR TITLE
Implement lazy loading for tournaments

### DIFF
--- a/application_service.py
+++ b/application_service.py
@@ -11,11 +11,11 @@ import logging
 import uuid
 from typing import List, Dict, Any, Optional
 from datetime import datetime
-import math # Для округления в BB
+import math  # Для округления в BB
 import re  # Добавить к существующим импортам
 
 import config
-from db.manager import database_manager # Используем синглтон менеджер БД
+from db.manager import database_manager  # Используем синглтон менеджер БД
 from db.repositories import (
     TournamentRepository,
     SessionRepository,
@@ -25,24 +25,25 @@ from db.repositories import (
 )
 from parsers import HandHistoryParser, TournamentSummaryParser
 from models import Tournament, Session, OverallStats, FinalTableHand
+
 # Импортируем плагины статистик (будут реализованы далее)
 from stats import (
-    BaseStat, # Базовый класс
+    BaseStat,  # Базовый класс
     BigKOStat,
     ITMStat,
     ROIStat,
     TotalKOStat,
-    AvgKOPerTournamentStat, # Новый
-    FinalTableReachStat, # Новый
-    AvgFTInitialStackStat, # Новый
-    EarlyFTKOStat, # Новый
+    AvgKOPerTournamentStat,  # Новый
+    FinalTableReachStat,  # Новый
+    AvgFTInitialStackStat,  # Новый
+    EarlyFTKOStat,  # Новый
     EarlyFTBustStat,
     AvgFinishPlaceStat,
     AvgFinishPlaceFTStat,
     AvgFinishPlaceNoFTStat,
 )
 
-logger = logging.getLogger('ROYAL_Stats.ApplicationService')
+logger = logging.getLogger("ROYAL_Stats.ApplicationService")
 logger.setLevel(logging.DEBUG if config.DEBUG else logging.INFO)
 
 # Список плагинов статистик, которые будем использовать
@@ -62,46 +63,53 @@ STAT_PLUGINS: List[BaseStat] = [
     AvgFinishPlaceNoFTStat(),
 ]
 
+
 def determine_file_type(file_path: str) -> Optional[str]:
     """
     Определяет тип покерного файла по первым двум строкам.
-    
+
     Returns:
         'ts' - Tournament Summary
-        'hh' - Hand History  
+        'hh' - Hand History
         None - файл не соответствует ожидаемым форматам
     """
     try:
-        with open(file_path, 'r', encoding='utf-8', errors='ignore') as f:
+        with open(file_path, "r", encoding="utf-8", errors="ignore") as f:
             lines = f.readlines()
-        
+
         # Нужно минимум 2 строки для проверки
         if len(lines) < 2:
             return None
-            
+
         first_line = lines[0].strip()
         second_line = lines[1].strip()
-        
+
         # Проверка Tournament Summary
-        if (first_line.startswith("Tournament #") and 
-            "Mystery Battle Royale" in first_line and 
-            second_line.startswith("Buy-in:")):
+        if (
+            first_line.startswith("Tournament #")
+            and "Mystery Battle Royale" in first_line
+            and second_line.startswith("Buy-in:")
+        ):
             logger.debug(f"Файл определен как Tournament Summary: {file_path}")
-            return 'ts'
-            
+            return "ts"
+
         # Проверка Hand History
-        if (first_line.startswith("Poker Hand #") and 
-            "Mystery Battle Royale" in first_line and 
-            second_line.startswith("Table")):
+        if (
+            first_line.startswith("Poker Hand #")
+            and "Mystery Battle Royale" in first_line
+            and second_line.startswith("Table")
+        ):
             logger.debug(f"Файл определен как Hand History: {file_path}")
-            return 'hh'
-            
+            return "hh"
+
         # Если не подходит ни под один формат
-        logger.debug(f"Файл отфильтрован (не соответствует покерным форматам): {file_path}")
+        logger.debug(
+            f"Файл отфильтрован (не соответствует покерным форматам): {file_path}"
+        )
         logger.debug(f"  1-я строка: {first_line[:50]}...")
         logger.debug(f"  2-я строка: {second_line[:50]}...")
         return None
-        
+
     except Exception as e:
         logger.warning(f"Не удалось прочитать файл {file_path}: {e}")
         return None
@@ -113,6 +121,7 @@ def is_poker_file(file_path: str) -> bool:
     Возвращает True, если файл соответствует ожидаемым форматам.
     """
     return determine_file_type(file_path) is not None
+
 
 class ApplicationService:
     """
@@ -129,7 +138,7 @@ class ApplicationService:
 
         self.hh_parser = HandHistoryParser()
         self.ts_parser = TournamentSummaryParser()
-        
+
     @property
     def db_path(self) -> str:
         """Возвращает путь к текущей базе данных."""
@@ -154,7 +163,9 @@ class ApplicationService:
         if os.path.exists(new_db_path):
             logger.warning(f"Попытка создать существующую БД: {new_db_path}")
             # Можно вернуть False или пробросить исключение, чтобы UI показал ошибку
-            raise FileExistsError(f"База данных '{os.path.basename(new_db_path)}' уже существует.")
+            raise FileExistsError(
+                f"База данных '{os.path.basename(new_db_path)}' уже существует."
+            )
 
         self.db.set_db_path(new_db_path)  # Устанавливаем новый путь
 
@@ -191,7 +202,7 @@ class ApplicationService:
         # Инициализируем единый прогресс-бар
         if progress_callback:
             progress_callback(0, 100, "Подготовка файлов...")
-        
+
         all_files_to_process = []
         filtered_files_count = 0
         for path in paths:
@@ -204,22 +215,28 @@ class ApplicationService:
                                 all_files_to_process.append(full_path)
                             else:
                                 filtered_files_count += 1
-                                logger.debug(f"Файл отфильтрован (нет покерных шаблонов): {fname}")
+                                logger.debug(
+                                    f"Файл отфильтрован (нет покерных шаблонов): {fname}"
+                                )
             elif os.path.isfile(path):
                 if path.lower().endswith((".txt")):
                     if is_poker_file(path):
                         all_files_to_process.append(path)
                     else:
                         filtered_files_count += 1
-                        logger.debug(f"Файл отфильтрован (нет покерных шаблонов): {os.path.basename(path)}")
+                        logger.debug(
+                            f"Файл отфильтрован (нет покерных шаблонов): {os.path.basename(path)}"
+                        )
         if filtered_files_count > 0:
-            logger.info(f"Отфильтровано {filtered_files_count} файлов без покерных шаблонов")
+            logger.info(
+                f"Отфильтровано {filtered_files_count} файлов без покерных шаблонов"
+            )
 
         total_files = len(all_files_to_process)
         if total_files == 0:
             logger.info("Нет файлов для обработки.")
             if progress_callback:
-                 progress_callback(0, 0, "Нет файлов для обработки")
+                progress_callback(0, 0, "Нет файлов для обработки")
             return
 
         # Рассчитываем общее количество шагов прогресса
@@ -228,12 +245,12 @@ class ApplicationService:
         # Сохранение в БД: примерно 20% от общего времени
         # Обновление статистики: примерно 10% от общего времени
         PARSING_WEIGHT = 70  # 70% времени на парсинг
-        SAVING_WEIGHT = 20   # 20% времени на сохранение
-        STATS_WEIGHT = 10    # 10% времени на обновление статистики
-        
+        SAVING_WEIGHT = 20  # 20% времени на сохранение
+        STATS_WEIGHT = 10  # 10% времени на обновление статистики
+
         total_steps = 100  # Работаем с процентами
         current_progress = 0
-        
+
         logger.info(
             f"Начат импорт {total_files} файлов в сессию"
             f" '{session_name if session_id is None else session_id}'"
@@ -254,9 +271,10 @@ class ApplicationService:
             except Exception as e:
                 logger.error(f"Не удалось создать сессию для импорта: {e}")
                 if progress_callback:
-                    progress_callback(0, total_steps, f"Ошибка: Не удалось создать сессию: {e}")
+                    progress_callback(
+                        0, total_steps, f"Ошибка: Не удалось создать сессию: {e}"
+                    )
                 return
-
 
         # Словарь для временного хранения данных турниров во время парсинга
         # Ключ: tournament_id, Значение: Dict с объединенными данными
@@ -266,8 +284,10 @@ class ApplicationService:
 
         # ЭТАП 1: Парсинг файлов
         if progress_callback:
-            progress_callback(current_progress, total_steps, "Начинаем обработку файлов...")
-        
+            progress_callback(
+                current_progress, total_steps, "Начинаем обработку файлов..."
+            )
+
         files_processed = 0
         for file_path in all_files_to_process:
             # Проверяем флаг отмены
@@ -275,90 +295,147 @@ class ApplicationService:
                 logger.warning(f"=== ИМПОРТ ОТМЕНЕН при парсинге файлов ===")
                 logger.info("Импорт отменен пользователем. Прерываем обработку файлов.")
                 if progress_callback:
-                    progress_callback(current_progress, total_steps, "Импорт отменен пользователем")
+                    progress_callback(
+                        current_progress, total_steps, "Импорт отменен пользователем"
+                    )
                 return
-            
+
             # Обновляем прогресс с учетом веса этапа парсинга
             file_progress = int((files_processed / total_files) * PARSING_WEIGHT)
             if progress_callback:
-                progress_callback(file_progress, total_steps, f"Обработка: {os.path.basename(file_path)}")
+                progress_callback(
+                    file_progress,
+                    total_steps,
+                    f"Обработка: {os.path.basename(file_path)}",
+                )
 
             try:
-                with open(file_path, 'r', encoding='utf-8', errors='ignore') as f:
+                with open(file_path, "r", encoding="utf-8", errors="ignore") as f:
                     content = f.read()
-                    
+
                 # Определяем тип файла
                 file_type = determine_file_type(file_path)
                 if file_type is None:
-                    logger.warning(f"Файл не соответствует ожидаемым форматам: {file_path}. Файл пропущен.")
+                    logger.warning(
+                        f"Файл не соответствует ожидаемым форматам: {file_path}. Файл пропущен."
+                    )
                     files_processed += 1
                     continue
 
-                is_ts = file_type == 'ts'
-                is_hh = file_type == 'hh'
+                is_ts = file_type == "ts"
+                is_hh = file_type == "hh"
 
-                
-                with open(file_path, 'r', encoding='utf-8', errors='ignore') as f:
+                with open(file_path, "r", encoding="utf-8", errors="ignore") as f:
                     content = f.read()
 
                 # Обрабатываем файл соответствующим парсером
                 if is_hh:
                     logger.debug(f"Обработка файла Hand History: {file_path}")
-                    hh_data = self.hh_parser.parse(content, filename=os.path.basename(file_path))
-                    tourney_id = hh_data.get('tournament_id')
-                    
+                    hh_data = self.hh_parser.parse(
+                        content, filename=os.path.basename(file_path)
+                    )
+                    tourney_id = hh_data.get("tournament_id")
+
                     # ОТЛАДКА: проверяем что вернул парсер
                     logger.info(f"=== ОТЛАДКА HH ПАРСЕР ===")
                     logger.info(f"Tournament ID: {tourney_id}")
-                    logger.info(f"Reached final table: {hh_data.get('reached_final_table', False)}")
-                    logger.info(f"Final table hands data: {len(hh_data.get('final_table_hands_data', []))} рук")
+                    logger.info(
+                        f"Reached final table: {hh_data.get('reached_final_table', False)}"
+                    )
+                    logger.info(
+                        f"Final table hands data: {len(hh_data.get('final_table_hands_data', []))} рук"
+                    )
 
                     if tourney_id:
                         # Инициализируем запись в словаре, если ее нет
                         if tourney_id not in parsed_tournaments_data:
-                             parsed_tournaments_data[tourney_id] = {'tournament_id': tourney_id, 'session_id': session_id, 'ko_count': 0, 'reached_final_table': False}
+                            parsed_tournaments_data[tourney_id] = {
+                                "tournament_id": tourney_id,
+                                "session_id": session_id,
+                                "ko_count": 0,
+                                "reached_final_table": False,
+                            }
 
                         # Добавляем данные из HH к временной записи турнира
-                        parsed_tournaments_data[tourney_id]['start_time'] = parsed_tournaments_data[tourney_id].get('start_time') or hh_data.get('start_time')
-                        
+                        parsed_tournaments_data[tourney_id]["start_time"] = (
+                            parsed_tournaments_data[tourney_id].get("start_time")
+                            or hh_data.get("start_time")
+                        )
+
                         # Обновляем временные данные турнира из HH
-                        if hh_data.get('reached_final_table', False):
-                             parsed_tournaments_data[tourney_id]['reached_final_table'] = True
-                             parsed_tournaments_data[tourney_id]['final_table_initial_stack_chips'] = hh_data.get('final_table_initial_stack_chips')
-                             parsed_tournaments_data[tourney_id]['final_table_initial_stack_bb'] = hh_data.get('final_table_initial_stack_bb')
+                        if hh_data.get("reached_final_table", False):
+                            parsed_tournaments_data[tourney_id][
+                                "reached_final_table"
+                            ] = True
+                            parsed_tournaments_data[tourney_id][
+                                "final_table_initial_stack_chips"
+                            ] = hh_data.get("final_table_initial_stack_chips")
+                            parsed_tournaments_data[tourney_id][
+                                "final_table_initial_stack_bb"
+                            ] = hh_data.get("final_table_initial_stack_bb")
 
                         # Собираем данные финальных раздач
-                        ft_hands_data = hh_data.get('final_table_hands_data', [])
-                        logger.debug(f"HH парсер вернул {len(ft_hands_data)} рук финального стола для турнира {tourney_id}")
+                        ft_hands_data = hh_data.get("final_table_hands_data", [])
+                        logger.debug(
+                            f"HH парсер вернул {len(ft_hands_data)} рук финального стола для турнира {tourney_id}"
+                        )
                         for hand_data in ft_hands_data:
-                             hand_data['session_id'] = session_id # Добавляем session_id к каждой руке
-                             all_final_table_hands_data.append(hand_data)
-                             logger.debug(f"Добавлена рука: tournament_id={hand_data.get('tournament_id')}, "
-                                        f"hand_id={hand_data.get('hand_id')}, "
-                                        f"table_size={hand_data.get('table_size')}, "
-                                        f"hero_ko={hand_data.get('hero_ko_this_hand')}")
-
+                            hand_data["session_id"] = (
+                                session_id  # Добавляем session_id к каждой руке
+                            )
+                            all_final_table_hands_data.append(hand_data)
+                            logger.debug(
+                                f"Добавлена рука: tournament_id={hand_data.get('tournament_id')}, "
+                                f"hand_id={hand_data.get('hand_id')}, "
+                                f"table_size={hand_data.get('table_size')}, "
+                                f"hero_ko={hand_data.get('hero_ko_this_hand')}"
+                            )
 
                 elif is_ts:
                     logger.debug(f"Обработка файла Tournament Summary: {file_path}")
-                    ts_data = self.ts_parser.parse(content, filename=os.path.basename(file_path))
-                    tourney_id = ts_data.get('tournament_id')
+                    ts_data = self.ts_parser.parse(
+                        content, filename=os.path.basename(file_path)
+                    )
+                    tourney_id = ts_data.get("tournament_id")
 
                     if tourney_id:
                         # Инициализируем запись, если ее нет
                         if tourney_id not in parsed_tournaments_data:
-                             parsed_tournaments_data[tourney_id] = {'tournament_id': tourney_id, 'session_id': session_id, 'ko_count': 0, 'reached_final_table': False} # Инициализируем ko_count=0
+                            parsed_tournaments_data[tourney_id] = {
+                                "tournament_id": tourney_id,
+                                "session_id": session_id,
+                                "ko_count": 0,
+                                "reached_final_table": False,
+                            }  # Инициализируем ko_count=0
 
                         # Обновляем временные данные турнира из TS (TS имеет приоритет по fin_place, payout, buyin, name, start_time)
-                        parsed_tournaments_data[tourney_id]['tournament_name'] = ts_data.get('tournament_name') or parsed_tournaments_data[tourney_id].get('tournament_name')
-                        parsed_tournaments_data[tourney_id]['start_time'] = ts_data.get('start_time') or parsed_tournaments_data[tourney_id].get('start_time')
-                        parsed_tournaments_data[tourney_id]['buyin'] = ts_data.get('buyin') or parsed_tournaments_data[tourney_id].get('buyin')
-                        parsed_tournaments_data[tourney_id]['payout'] = ts_data.get('payout') or parsed_tournaments_data[tourney_id].get('payout')
-                        parsed_tournaments_data[tourney_id]['finish_place'] = ts_data.get('finish_place') or parsed_tournaments_data[tourney_id].get('finish_place') # finish_place 0 или None из HH, TS должно переписать
+                        parsed_tournaments_data[tourney_id]["tournament_name"] = (
+                            ts_data.get("tournament_name")
+                            or parsed_tournaments_data[tourney_id].get(
+                                "tournament_name"
+                            )
+                        )
+                        parsed_tournaments_data[tourney_id]["start_time"] = ts_data.get(
+                            "start_time"
+                        ) or parsed_tournaments_data[tourney_id].get("start_time")
+                        parsed_tournaments_data[tourney_id]["buyin"] = ts_data.get(
+                            "buyin"
+                        ) or parsed_tournaments_data[tourney_id].get("buyin")
+                        parsed_tournaments_data[tourney_id]["payout"] = ts_data.get(
+                            "payout"
+                        ) or parsed_tournaments_data[tourney_id].get("payout")
+                        parsed_tournaments_data[tourney_id][
+                            "finish_place"
+                        ] = ts_data.get("finish_place") or parsed_tournaments_data[
+                            tourney_id
+                        ].get(
+                            "finish_place"
+                        )  # finish_place 0 или None из HH, TS должно переписать
 
                         # Логируем найденные значения для отладки
-                        logger.debug(f"TS данные для {tourney_id}: name={ts_data.get('tournament_name')}, buyin={ts_data.get('buyin')}, payout={ts_data.get('payout')}, place={ts_data.get('finish_place')}")
-
+                        logger.debug(
+                            f"TS данные для {tourney_id}: name={ts_data.get('tournament_name')}, buyin={ts_data.get('buyin')}, payout={ts_data.get('payout')}, place={ts_data.get('finish_place')}"
+                        )
 
             except Exception as e:
                 logger.error(f"Ошибка обработки файла {file_path}: {e}")
@@ -366,109 +443,155 @@ class ApplicationService:
 
             files_processed += 1
 
-
         # Завершаем этап парсинга
         current_progress = PARSING_WEIGHT
 
         # --- Сохранение данных в БД ---
         logger.info(f"=== ОТЛАДКА ПЕРЕД СОХРАНЕНИЕМ ===")
-        logger.info(f"Всего рук финального стола для сохранения: {len(all_final_table_hands_data)}")
+        logger.info(
+            f"Всего рук финального стола для сохранения: {len(all_final_table_hands_data)}"
+        )
         if all_final_table_hands_data:
             logger.info(f"Пример первой руки: {all_final_table_hands_data[0]}")
-        
+
         # ЭТАП 2: Сохранение данных в БД
         # Проверяем флаг отмены перед сохранением в БД
         if is_canceled_callback and is_canceled_callback():
             logger.warning(f"=== ИМПОРТ ОТМЕНЕН перед сохранением в БД ===")
-            logger.info("Импорт отменен пользователем. Пропускаем сохранение данных в БД.")
+            logger.info(
+                "Импорт отменен пользователем. Пропускаем сохранение данных в БД."
+            )
             if progress_callback:
-                progress_callback(current_progress, total_steps, "Импорт отменен пользователем")
+                progress_callback(
+                    current_progress, total_steps, "Импорт отменен пользователем"
+                )
             return
-            
+
         logger.info("Сохранение обработанных данных в БД...")
         if progress_callback:
-            progress_callback(current_progress, total_steps, "Сохранение данных в базу...")
+            progress_callback(
+                current_progress, total_steps, "Сохранение данных в базу..."
+            )
 
         # 1. СНАЧАЛА сохраняем/обновляем данные турниров
-        
+
         tournaments_saved = 0
         total_tournaments = len(parsed_tournaments_data)
-        
+
         for tourney_id, data in parsed_tournaments_data.items():
-             try:
-                 # Запрашиваем текущий турнир для merge
-                 existing_tourney = self.tournament_repo.get_tournament_by_id(tourney_id)
+            try:
+                # Запрашиваем текущий турнир для merge
+                existing_tourney = self.tournament_repo.get_tournament_by_id(tourney_id)
 
-                 # Объединяем данные: TS > HH > Existing
-                 final_tourney_data = {}
-                 if existing_tourney:
-                     final_tourney_data.update(existing_tourney.as_dict()) # Base from existing
+                # Объединяем данные: TS > HH > Existing
+                final_tourney_data = {}
+                if existing_tourney:
+                    final_tourney_data.update(
+                        existing_tourney.as_dict()
+                    )  # Base from existing
 
-                 final_tourney_data.update(data) # Override with data from parsed file batch
+                final_tourney_data.update(
+                    data
+                )  # Override with data from parsed file batch
 
-                 # Специальная логика для полей, которые должны объединяться, а не перезаписываться
-                 # reached_final_table = Existing OR New
-                 if existing_tourney and existing_tourney.reached_final_table:
-                     final_tourney_data['reached_final_table'] = True # Если хоть раз достигли финалки, флаг остается TRUE
+                # Специальная логика для полей, которые должны объединяться, а не перезаписываться
+                # reached_final_table = Existing OR New
+                if existing_tourney and existing_tourney.reached_final_table:
+                    final_tourney_data["reached_final_table"] = (
+                        True  # Если хоть раз достигли финалки, флаг остается TRUE
+                    )
 
-                 # final_table_initial_stack - сохраняем только если это первая раздача финалки в истории парсинга этого турнира
-                 if existing_tourney and existing_tourney.final_table_initial_stack_chips is not None:
-                      # Если стек уже сохранен в БД, не перезаписываем его
-                      final_tourney_data['final_table_initial_stack_chips'] = existing_tourney.final_table_initial_stack_chips
-                      final_tourney_data['final_table_initial_stack_bb'] = existing_tourney.final_table_initial_stack_bb
+                # final_table_initial_stack - сохраняем только если это первая раздача финалки в истории парсинга этого турнира
+                if (
+                    existing_tourney
+                    and existing_tourney.final_table_initial_stack_chips is not None
+                ):
+                    # Если стек уже сохранен в БД, не перезаписываем его
+                    final_tourney_data["final_table_initial_stack_chips"] = (
+                        existing_tourney.final_table_initial_stack_chips
+                    )
+                    final_tourney_data["final_table_initial_stack_bb"] = (
+                        existing_tourney.final_table_initial_stack_bb
+                    )
 
-                 # session_id - сохраняем первый session_id, связанный с этим турниром
-                 if existing_tourney and existing_tourney.session_id:
-                      final_tourney_data['session_id'] = existing_tourney.session_id
+                # session_id - сохраняем первый session_id, связанный с этим турниром
+                if existing_tourney and existing_tourney.session_id:
+                    final_tourney_data["session_id"] = existing_tourney.session_id
 
+                # Логируем финальные данные турнира перед сохранением
+                logger.debug(
+                    f"Сохранение турнира {tourney_id}: name={final_tourney_data.get('tournament_name')}, "
+                    f"buyin={final_tourney_data.get('buyin')}, payout={final_tourney_data.get('payout')}, "
+                    f"place={final_tourney_data.get('finish_place')}"
+                )
 
-                 # Логируем финальные данные турнира перед сохранением
-                 logger.debug(f"Сохранение турнира {tourney_id}: name={final_tourney_data.get('tournament_name')}, " 
-                            f"buyin={final_tourney_data.get('buyin')}, payout={final_tourney_data.get('payout')}, "
-                            f"place={final_tourney_data.get('finish_place')}")
+                # Создаем объект Tournament из объединенных данных
+                merged_tournament = Tournament.from_dict(final_tourney_data)
+                self.tournament_repo.add_or_update_tournament(merged_tournament)
+                tournaments_saved += 1
 
-                 # Создаем объект Tournament из объединенных данных
-                 merged_tournament = Tournament.from_dict(final_tourney_data)
-                 self.tournament_repo.add_or_update_tournament(merged_tournament)
-                 tournaments_saved += 1
-                 
-                 # Обновляем прогресс
-                 if tournaments_saved % 5 == 0 or tournaments_saved == total_tournaments:
-                     save_progress = current_progress + int((tournaments_saved / max(total_tournaments, 1)) * (SAVING_WEIGHT * 0.4))
-                     if progress_callback:
-                         progress_callback(save_progress, total_steps, f"Сохранено турниров: {tournaments_saved}/{total_tournaments}")
+                # Обновляем прогресс
+                if tournaments_saved % 5 == 0 or tournaments_saved == total_tournaments:
+                    save_progress = current_progress + int(
+                        (tournaments_saved / max(total_tournaments, 1))
+                        * (SAVING_WEIGHT * 0.4)
+                    )
+                    if progress_callback:
+                        progress_callback(
+                            save_progress,
+                            total_steps,
+                            f"Сохранено турниров: {tournaments_saved}/{total_tournaments}",
+                        )
 
-             except Exception as e:
-                  logger.error(f"Ошибка сохранения/обновления турнира {tourney_id}: {e}")
+            except Exception as e:
+                logger.error(f"Ошибка сохранения/обновления турнира {tourney_id}: {e}")
 
         logger.info(f"Сохранено/обновлено {tournaments_saved} турниров.")
 
         # 2. ТЕПЕРЬ сохраняем данные финальных раздач (с ON CONFLICT DO NOTHING)
-        logger.info(f"Начинаем сохранение {len(all_final_table_hands_data)} рук финального стола")
+        logger.info(
+            f"Начинаем сохранение {len(all_final_table_hands_data)} рук финального стола"
+        )
         total_hands_to_save = len(all_final_table_hands_data)
         hands_saved = 0
-        
+
         for hand_data in all_final_table_hands_data:
-             try:
-                  logger.debug(f"Сохраняем руку: {hand_data}")
-                  hand = FinalTableHand.from_dict(hand_data)
-                  self.ft_hand_repo.add_hand(hand)
-                  hands_saved += 1
-                  logger.debug(f"Рука сохранена успешно: {hand.hand_id}")
-                  
-                  # Обновляем прогресс для сохранения рук
-                  if hands_saved % 10 == 0 or hands_saved == total_hands_to_save:  # Обновляем каждые 10 рук
-                      hands_progress = current_progress + int(SAVING_WEIGHT * 0.4) + int((hands_saved / max(total_hands_to_save, 1)) * (SAVING_WEIGHT * 0.4))
-                      if progress_callback:
-                          progress_callback(hands_progress, total_steps, f"Сохранено рук: {hands_saved}/{total_hands_to_save}")
-                          
-             except Exception as e:
-                  logger.error(f"Ошибка сохранения финальной раздачи {hand_data.get('hand_id')} турнира {hand_data.get('tournament_id')}: {e}")
-                  import traceback
-                  logger.error(f"Traceback: {traceback.format_exc()}")
-        
+            try:
+                logger.debug(f"Сохраняем руку: {hand_data}")
+                hand = FinalTableHand.from_dict(hand_data)
+                self.ft_hand_repo.add_hand(hand)
+                hands_saved += 1
+                logger.debug(f"Рука сохранена успешно: {hand.hand_id}")
+
+                # Обновляем прогресс для сохранения рук
+                if (
+                    hands_saved % 10 == 0 or hands_saved == total_hands_to_save
+                ):  # Обновляем каждые 10 рук
+                    hands_progress = (
+                        current_progress
+                        + int(SAVING_WEIGHT * 0.4)
+                        + int(
+                            (hands_saved / max(total_hands_to_save, 1))
+                            * (SAVING_WEIGHT * 0.4)
+                        )
+                    )
+                    if progress_callback:
+                        progress_callback(
+                            hands_progress,
+                            total_steps,
+                            f"Сохранено рук: {hands_saved}/{total_hands_to_save}",
+                        )
+
+            except Exception as e:
+                logger.error(
+                    f"Ошибка сохранения финальной раздачи {hand_data.get('hand_id')} турнира {hand_data.get('tournament_id')}: {e}"
+                )
+                import traceback
+
+                logger.error(f"Traceback: {traceback.format_exc()}")
+
         logger.info(f"Сохранение рук завершено: {hands_saved} из {total_hands_to_save}")
-        
+
         # Добавить явный commit после сохранения всех рук
         if hands_saved > 0:
             try:
@@ -481,78 +604,111 @@ class ApplicationService:
         # 3. Подсчитываем ko_count для каждого турнира на основе сохраненных рук
         logger.info("Подсчет ko_count для турниров...")
         if progress_callback:
-            progress_callback(current_progress + int(SAVING_WEIGHT * 0.8), total_steps, "Подсчет нокаутов...")
-        
+            progress_callback(
+                current_progress + int(SAVING_WEIGHT * 0.8),
+                total_steps,
+                "Подсчет нокаутов...",
+            )
+
         tournaments_processed = 0
-        
+
         tournaments_processed = 0
-        
+
         for tourney_id in parsed_tournaments_data:
             try:
                 # Получаем все руки финального стола для этого турнира из БД
-                tournament_ft_hands = self.ft_hand_repo.get_hands_by_tournament(tourney_id)
+                tournament_ft_hands = self.ft_hand_repo.get_hands_by_tournament(
+                    tourney_id
+                )
                 # Суммируем KO из всех рук
                 total_ko = sum(hand.hero_ko_this_hand for hand in tournament_ft_hands)
                 # Обновляем ko_count в parsed_tournaments_data
-                parsed_tournaments_data[tourney_id]['ko_count'] = total_ko
+                parsed_tournaments_data[tourney_id]["ko_count"] = total_ko
                 if total_ko > 0:
-                    logger.debug(f"Турнир {tourney_id}: найдено {total_ko} KO в {len(tournament_ft_hands)} руках")
+                    logger.debug(
+                        f"Турнир {tourney_id}: найдено {total_ko} KO в {len(tournament_ft_hands)} руках"
+                    )
                 tournaments_processed += 1
-                
+
                 # Обновляем прогресс
-                if tournaments_processed % 5 == 0 or tournaments_processed == total_tournaments:
-                    ko_progress = current_progress + int(SAVING_WEIGHT * 0.8) + int((tournaments_processed / max(total_tournaments, 1)) * (SAVING_WEIGHT * 0.2))
+                if (
+                    tournaments_processed % 5 == 0
+                    or tournaments_processed == total_tournaments
+                ):
+                    ko_progress = (
+                        current_progress
+                        + int(SAVING_WEIGHT * 0.8)
+                        + int(
+                            (tournaments_processed / max(total_tournaments, 1))
+                            * (SAVING_WEIGHT * 0.2)
+                        )
+                    )
                     if progress_callback:
-                        progress_callback(ko_progress, total_steps, f"Обработано турниров: {tournaments_processed}/{total_tournaments}")
-                        
+                        progress_callback(
+                            ko_progress,
+                            total_steps,
+                            f"Обработано турниров: {tournaments_processed}/{total_tournaments}",
+                        )
+
             except Exception as e:
                 logger.error(f"Ошибка подсчета KO для турнира {tourney_id}: {e}")
 
         current_progress = PARSING_WEIGHT + SAVING_WEIGHT
-        logger.info(f"Сохранено/обновлено {tournaments_saved} турниров. Сохранено {len(all_final_table_hands_data)} рук финального стола.")
-
+        logger.info(
+            f"Сохранено/обновлено {tournaments_saved} турниров. Сохранено {len(all_final_table_hands_data)} рук финального стола."
+        )
 
         # --- Обновление статистики ---
         # ЭТАП 3: Обновление статистики
         # Проверяем флаг отмены перед обновлением статистики
         if is_canceled_callback and is_canceled_callback():
             logger.warning(f"=== ИМПОРТ ОТМЕНЕН перед обновлением статистики ===")
-            logger.info("Импорт отменен пользователем. Пропускаем обновление статистики.")
+            logger.info(
+                "Импорт отменен пользователем. Пропускаем обновление статистики."
+            )
             if progress_callback:
-                progress_callback(current_progress, total_steps, "Импорт отменен пользователем")
+                progress_callback(
+                    current_progress, total_steps, "Импорт отменен пользователем"
+                )
             return
-            
+
         logger.info("Обновление агрегированной статистики...")
         if progress_callback:
             progress_callback(current_progress, total_steps, "Обновление статистики...")
-        
-        try:
-             # Передаем callback в _update_all_statistics для отслеживания прогресса
-             self._update_all_statistics(
-                 session_id,
-                 progress_callback=lambda step, total, text="": progress_callback(
-                     current_progress + int((step / total) * STATS_WEIGHT),
-                     total_steps,
-                     text or "Обновление статистики..."
-                 ),
-             )
-             logger.info("Обновление статистики завершено.")
-        except Exception as e:
-             logger.error(f"Ошибка при обновлении статистики: {e}")
-             if progress_callback:
-                  progress_callback(total_steps, total_steps, f"Ошибка при обновлении статистики: {e}")
-             # В реальном приложении здесь может потребоваться более детальная обработка
-             return
 
-            # В самом конце метода import_files
+        try:
+            # Передаем callback в _update_all_statistics для отслеживания прогресса
+            self._update_all_statistics(
+                session_id,
+                progress_callback=lambda step, total, text="": progress_callback(
+                    current_progress + int((step / total) * STATS_WEIGHT),
+                    total_steps,
+                    text or "Обновление статистики...",
+                ),
+            )
+            logger.info("Обновление статистики завершено.")
+        except Exception as e:
+            logger.error(f"Ошибка при обновлении статистики: {e}")
+            if progress_callback:
+                progress_callback(
+                    total_steps, total_steps, f"Ошибка при обновлении статистики: {e}"
+                )
+            # В реальном приложении здесь может потребоваться более детальная обработка
+            return
+
+        # В самом конце метода import_files
         logger.info("=== ПРОВЕРКА БД ПОСЛЕ ИМПОРТА ===")
         test_query = "SELECT COUNT(*) FROM hero_final_table_hands"
         result = self.db.execute_query(test_query)
-        logger.info(f"Количество рук в hero_final_table_hands: {result[0][0] if result else 0}")
+        logger.info(
+            f"Количество рук в hero_final_table_hands: {result[0][0] if result else 0}"
+        )
 
-        test_query2 = "SELECT COUNT(*) FROM tournaments"  
+        test_query2 = "SELECT COUNT(*) FROM tournaments"
         result2 = self.db.execute_query(test_query2)
-        logger.info(f"Количество турниров в tournaments: {result2[0][0] if result2 else 0}")
+        logger.info(
+            f"Количество турниров в tournaments: {result2[0][0] if result2 else 0}"
+        )
 
         # Завершение импорта
         if progress_callback:
@@ -564,33 +720,46 @@ class ApplicationService:
         Вызывается после импорта данных.
         """
         logger.debug("Запущен пересчет всей статистики.")
-        
+
         # Предварительно загружаем данные для оценки объема работы
         all_tournaments = self.tournament_repo.get_all_tournaments()
         all_final_tournaments = [
-            t for t in all_tournaments
-            if t.reached_final_table and t.finish_place is not None and 1 <= t.finish_place <= 9
+            t
+            for t in all_tournaments
+            if t.reached_final_table
+            and t.finish_place is not None
+            and 1 <= t.finish_place <= 9
         ]
         sessions_to_update = self.session_repo.get_all_sessions()
 
         # Общее количество операций для прогресса
-        total_steps = 1 + len(all_final_tournaments) + len(all_tournaments) + len(sessions_to_update)
+        total_steps = (
+            1
+            + len(all_final_tournaments)
+            + len(all_tournaments)
+            + len(sessions_to_update)
+        )
         current_step = 0
 
         # --- Обновление Overall Stats ---
         try:
             if progress_callback:
-                progress_callback(current_step, total_steps, "Обновление общей статистики...")
+                progress_callback(
+                    current_step, total_steps, "Обновление общей статистики..."
+                )
             logger.debug("Обновление общей статистики...")
             overall_stats = self._calculate_overall_stats()
             self.overall_stats_repo.update_overall_stats(overall_stats)
             logger.info("Общая статистика обновлена успешно.")
             current_step += 1
             if progress_callback:
-                progress_callback(current_step, total_steps, "Общая статистика обновлена")
+                progress_callback(
+                    current_step, total_steps, "Общая статистика обновлена"
+                )
         except Exception as e:
             logger.error(f"Ошибка при обновлении overall_stats: {e}")
             import traceback
+
             logger.error(f"Traceback: {traceback.format_exc()}")
 
         # --- Обновление Place Distribution ---
@@ -601,28 +770,42 @@ class ApplicationService:
                 self.place_dist_repo.increment_place_count(tourney.finish_place)
                 current_step += 1
                 if progress_callback:
-                    progress_callback(current_step, total_steps, f"Обновлено мест: {current_step-1}/{len(all_final_tournaments)}")
-            logger.info(f"Распределение мест обновлено для {len(all_final_tournaments)} турниров.")
+                    progress_callback(
+                        current_step,
+                        total_steps,
+                        f"Обновлено мест: {current_step-1}/{len(all_final_tournaments)}",
+                    )
+            logger.info(
+                f"Распределение мест обновлено для {len(all_final_tournaments)} турниров."
+            )
         except Exception as e:
             logger.error(f"Ошибка при обновлении place_distribution: {e}")
             import traceback
+
             logger.error(f"Traceback: {traceback.format_exc()}")
 
         # --- Обновление KO count для турниров ---
         try:
             logger.debug("Обновление ko_count для турниров...")
             for tournament in all_tournaments:
-                tournament_ft_hands = self.ft_hand_repo.get_hands_by_tournament(tournament.tournament_id)
+                tournament_ft_hands = self.ft_hand_repo.get_hands_by_tournament(
+                    tournament.tournament_id
+                )
                 total_ko = sum(hand.hero_ko_this_hand for hand in tournament_ft_hands)
                 tournament.ko_count = total_ko
                 self.tournament_repo.add_or_update_tournament(tournament)
                 current_step += 1
                 if progress_callback:
-                    progress_callback(current_step, total_steps, f"Обновлено турниров: {current_step - 1 - len(all_final_tournaments)}/{len(all_tournaments)}")
+                    progress_callback(
+                        current_step,
+                        total_steps,
+                        f"Обновлено турниров: {current_step - 1 - len(all_final_tournaments)}/{len(all_tournaments)}",
+                    )
             logger.info(f"KO count обновлен для {len(all_tournaments)} турниров.")
         except Exception as e:
             logger.error(f"Ошибка при обновлении ko_count: {e}")
             import traceback
+
             logger.error(f"Traceback: {traceback.format_exc()}")
 
         # --- Обновление Session Stats ---
@@ -632,14 +815,21 @@ class ApplicationService:
                 try:
                     self._calculate_and_update_session_stats(session.session_id)
                 except Exception as e:
-                    logger.error(f"Ошибка при обновлении сессии {session.session_id}: {e}")
+                    logger.error(
+                        f"Ошибка при обновлении сессии {session.session_id}: {e}"
+                    )
                 current_step += 1
                 if progress_callback:
-                    progress_callback(current_step, total_steps, f"Обновлено сессий: {current_step - 1 - len(all_final_tournaments) - len(all_tournaments)}/{len(sessions_to_update)}")
+                    progress_callback(
+                        current_step,
+                        total_steps,
+                        f"Обновлено сессий: {current_step - 1 - len(all_final_tournaments) - len(all_tournaments)}/{len(sessions_to_update)}",
+                    )
             logger.info(f"Статистика обновлена для {len(sessions_to_update)} сессий.")
         except Exception as e:
             logger.error(f"Ошибка при обновлении session stats: {e}")
             import traceback
+
             logger.error(f"Traceback: {traceback.format_exc()}")
 
         if progress_callback:
@@ -647,21 +837,26 @@ class ApplicationService:
 
         logger.info("Обновление всей статистики завершено (с учетом возможных ошибок).")
 
-
     def _calculate_overall_stats(self) -> OverallStats:
         """
         Рассчитывает все показатели для OverallStats на основе данных из БД.
         """
         all_tournaments = self.tournament_repo.get_all_tournaments()
-        all_ft_hands = self.ft_hand_repo.get_all_hands() # Все руки финалок
-        logger.info(f"_calculate_overall_stats: Загружено {len(all_tournaments)} турниров")
-        logger.info(f"_calculate_overall_stats: Загружено {len(all_ft_hands)} рук финального стола")
+        all_ft_hands = self.ft_hand_repo.get_all_hands()  # Все руки финалок
+        logger.info(
+            f"_calculate_overall_stats: Загружено {len(all_tournaments)} турниров"
+        )
+        logger.info(
+            f"_calculate_overall_stats: Загружено {len(all_ft_hands)} рук финального стола"
+        )
         # Проверяем содержимое первого турнира для отладки
         if all_tournaments:
             t = all_tournaments[0]
-            logger.debug(f"Пример турнира: id={t.tournament_id}, buyin={t.buyin}, payout={t.payout}, place={t.finish_place}, ft={t.reached_final_table}, ko={t.ko_count}")
+            logger.debug(
+                f"Пример турнира: id={t.tournament_id}, buyin={t.buyin}, payout={t.payout}, place={t.finish_place}, ft={t.reached_final_table}, ko={t.ko_count}"
+            )
 
-        stats = OverallStats() # Создаем объект с дефолтными значениями
+        stats = OverallStats()  # Создаем объект с дефолтными значениями
 
         stats.total_tournaments = len(all_tournaments)
 
@@ -670,16 +865,30 @@ class ApplicationService:
         stats.total_final_tables = len(final_table_tournaments)
 
         # Расчеты, основанные на турнирах:
-        stats.total_buy_in = sum(t.buyin for t in all_tournaments if t.buyin is not None)
-        stats.total_prize = sum(t.payout if t.payout is not None else 0 for t in all_tournaments)
+        stats.total_buy_in = sum(
+            t.buyin for t in all_tournaments if t.buyin is not None
+        )
+        stats.total_prize = sum(
+            t.payout if t.payout is not None else 0 for t in all_tournaments
+        )
 
         # Среднее место по всем турнирам (включая не финалку)
-        all_places = [t.finish_place for t in all_tournaments if t.finish_place is not None]
-        stats.avg_finish_place = sum(all_places) / len(all_places) if all_places else 0.0
+        all_places = [
+            t.finish_place for t in all_tournaments if t.finish_place is not None
+        ]
+        stats.avg_finish_place = (
+            sum(all_places) / len(all_places) if all_places else 0.0
+        )
 
         # Среднее место только на финалке (1-9)
-        ft_places = [t.finish_place for t in final_table_tournaments if t.finish_place is not None and 1 <= t.finish_place <= 9]
-        stats.avg_finish_place_ft = sum(ft_places) / len(ft_places) if ft_places else 0.0
+        ft_places = [
+            t.finish_place
+            for t in final_table_tournaments
+            if t.finish_place is not None and 1 <= t.finish_place <= 9
+        ]
+        stats.avg_finish_place_ft = (
+            sum(ft_places) / len(ft_places) if ft_places else 0.0
+        )
 
         # Общее количество KO - суммируем hero_ko_this_hand из всех рук финального стола
         # Обновленный HandHistoryParser точно определяет выбывших игроков путем сравнения
@@ -688,25 +897,52 @@ class ApplicationService:
         logger.info(f"Рассчитано total_knockouts: {stats.total_knockouts}")
 
         # Avg KO / Tournament (по всем турнирам, включая не финалку)
-        stats.avg_ko_per_tournament = stats.total_knockouts / stats.total_tournaments if stats.total_tournaments > 0 else 0.0
+        stats.avg_ko_per_tournament = (
+            stats.total_knockouts / stats.total_tournaments
+            if stats.total_tournaments > 0
+            else 0.0
+        )
 
         # % Reach FT
-        stats.final_table_reach_percent = (stats.total_final_tables / stats.total_tournaments * 100) if stats.total_tournaments > 0 else 0.0
-
+        stats.final_table_reach_percent = (
+            (stats.total_final_tables / stats.total_tournaments * 100)
+            if stats.total_tournaments > 0
+            else 0.0
+        )
 
         # Средний стек на старте финалки (чипсы и BB)
-        ft_initial_stacks_chips = [t.final_table_initial_stack_chips for t in final_table_tournaments if t.final_table_initial_stack_chips is not None]
-        stats.avg_ft_initial_stack_chips = sum(ft_initial_stacks_chips) / len(ft_initial_stacks_chips) if ft_initial_stacks_chips else 0.0
+        ft_initial_stacks_chips = [
+            t.final_table_initial_stack_chips
+            for t in final_table_tournaments
+            if t.final_table_initial_stack_chips is not None
+        ]
+        stats.avg_ft_initial_stack_chips = (
+            sum(ft_initial_stacks_chips) / len(ft_initial_stacks_chips)
+            if ft_initial_stacks_chips
+            else 0.0
+        )
 
-        ft_initial_stacks_bb = [t.final_table_initial_stack_bb for t in final_table_tournaments if t.final_table_initial_stack_bb is not None]
-        stats.avg_ft_initial_stack_bb = sum(ft_initial_stacks_bb) / len(ft_initial_stacks_bb) if ft_initial_stacks_bb else 0.0
+        ft_initial_stacks_bb = [
+            t.final_table_initial_stack_bb
+            for t in final_table_tournaments
+            if t.final_table_initial_stack_bb is not None
+        ]
+        stats.avg_ft_initial_stack_bb = (
+            sum(ft_initial_stacks_bb) / len(ft_initial_stacks_bb)
+            if ft_initial_stacks_bb
+            else 0.0
+        )
 
         # Расчеты для "ранней стадии финалки" (9-6 игроков)
         early_ft_hands = [hand for hand in all_ft_hands if hand.is_early_final]
         stats.early_ft_ko_count = sum(hand.hero_ko_this_hand for hand in early_ft_hands)
 
         # Среднее KO в ранней финалке на турнир (считаем только для турниров, достигших финалки)
-        stats.early_ft_ko_per_tournament = stats.early_ft_ko_count / stats.total_final_tables if stats.total_final_tables > 0 else 0.0
+        stats.early_ft_ko_per_tournament = (
+            stats.early_ft_ko_count / stats.total_final_tables
+            if stats.total_final_tables > 0
+            else 0.0
+        )
 
         # Вылеты Hero на ранней стадии финалки (6-9 место)
         stats.early_ft_bust_count = sum(
@@ -715,24 +951,41 @@ class ApplicationService:
             if t.finish_place is not None and 6 <= t.finish_place <= 9
         )
         stats.early_ft_bust_per_tournament = (
-            stats.early_ft_bust_count / stats.total_final_tables if stats.total_final_tables > 0 else 0.0
+            stats.early_ft_bust_count / stats.total_final_tables
+            if stats.total_final_tables > 0
+            else 0.0
         )
 
         # Логируем статистику по выплатам для отладки
-        tournaments_with_payout = sum(1 for t in all_tournaments if t.payout is not None and t.payout > 0)
-        tournaments_without_payout = sum(1 for t in all_tournaments if t.payout is None or t.payout == 0)
-        logger.info(f"Турниры с выплатами: {tournaments_with_payout}, без выплат: {tournaments_without_payout}")
+        tournaments_with_payout = sum(
+            1 for t in all_tournaments if t.payout is not None and t.payout > 0
+        )
+        tournaments_without_payout = sum(
+            1 for t in all_tournaments if t.payout is None or t.payout == 0
+        )
+        logger.info(
+            f"Турниры с выплатами: {tournaments_with_payout}, без выплат: {tournaments_without_payout}"
+        )
 
         # Логируем примеры турниров с выплатами для отладки Big KO
-        tournaments_with_big_payout = [t for t in all_tournaments 
-                                      if t.payout is not None and t.payout > 0 and t.buyin is not None 
-                                      and t.payout >= t.buyin * 10]
+        tournaments_with_big_payout = [
+            t
+            for t in all_tournaments
+            if t.payout is not None
+            and t.payout > 0
+            and t.buyin is not None
+            and t.payout >= t.buyin * 10
+        ]
         if tournaments_with_big_payout:
-            logger.info(f"Найдено {len(tournaments_with_big_payout)} турниров с выплатой >= 10x buyin:")
+            logger.info(
+                f"Найдено {len(tournaments_with_big_payout)} турниров с выплатой >= 10x buyin:"
+            )
             for t in tournaments_with_big_payout[:5]:  # Показываем первые 5
-                logger.info(f"  - Турнир {t.tournament_id}: место {t.finish_place}, "
-                           f"buyin=${t.buyin}, payout=${t.payout} "
-                           f"(ratio: {t.payout/t.buyin:.1f}x)")
+                logger.info(
+                    f"  - Турнир {t.tournament_id}: место {t.finish_place}, "
+                    f"buyin=${t.buyin}, payout=${t.payout} "
+                    f"(ratio: {t.payout/t.buyin:.1f}x)"
+                )
 
         # Расчет Big KO (требует buyin и payout из турниров)
         big_ko_results = BigKOStat().compute(all_tournaments, all_ft_hands, [], None)
@@ -744,11 +997,15 @@ class ApplicationService:
         stats.big_ko_x1000 = big_ko_results.get("x1000", 0)
         stats.big_ko_x10000 = big_ko_results.get("x10000", 0)
 
-
         # Среднее место когда НЕ дошел до финалки
-        no_ft_places = [t.finish_place for t in all_tournaments 
-                       if not t.reached_final_table and t.finish_place is not None]
-        stats.avg_finish_place_no_ft = sum(no_ft_places) / len(no_ft_places) if no_ft_places else 0.0
+        no_ft_places = [
+            t.finish_place
+            for t in all_tournaments
+            if not t.reached_final_table and t.finish_place is not None
+        ]
+        stats.avg_finish_place_no_ft = (
+            sum(no_ft_places) / len(no_ft_places) if no_ft_places else 0.0
+        )
         stats.avg_finish_place_no_ft = round(stats.avg_finish_place_no_ft, 2)
 
         # Можно округлить некоторые значения для хранения
@@ -758,10 +1015,14 @@ class ApplicationService:
         stats.avg_ft_initial_stack_chips = round(stats.avg_ft_initial_stack_chips, 2)
         stats.avg_ft_initial_stack_bb = round(stats.avg_ft_initial_stack_bb, 2)
         stats.early_ft_ko_per_tournament = round(stats.early_ft_ko_per_tournament, 2)
-        stats.early_ft_bust_per_tournament = round(stats.early_ft_bust_per_tournament, 2)
+        stats.early_ft_bust_per_tournament = round(
+            stats.early_ft_bust_per_tournament, 2
+        )
         stats.final_table_reach_percent = round(stats.final_table_reach_percent, 2)
 
-        logger.info(f"Итоговая статистика: tournaments={stats.total_tournaments}, knockouts={stats.total_knockouts}, prize={stats.total_prize}, buyin={stats.total_buy_in}")
+        logger.info(
+            f"Итоговая статистика: tournaments={stats.total_tournaments}, knockouts={stats.total_knockouts}, prize={stats.total_prize}, buyin={stats.total_buy_in}"
+        )
         return stats
 
     def _calculate_and_update_session_stats(self, session_id: str):
@@ -771,31 +1032,49 @@ class ApplicationService:
         logger.debug(f"Расчет статистики для сессии {session_id}")
         session = self.session_repo.get_session_by_id(session_id)
         if not session:
-            logger.warning(f"Сессия с ID {session_id} не найдена для обновления статистики.")
+            logger.warning(
+                f"Сессия с ID {session_id} не найдена для обновления статистики."
+            )
             return
 
-        tournaments_in_session = self.tournament_repo.get_all_tournaments(session_id=session_id)
-        ft_hands_in_session = self.ft_hand_repo.get_hands_by_session(session_id=session_id)
-
+        tournaments_in_session = self.tournament_repo.get_all_tournaments(
+            session_id=session_id
+        )
+        ft_hands_in_session = self.ft_hand_repo.get_hands_by_session(
+            session_id=session_id
+        )
 
         session.tournaments_count = len(tournaments_in_session)
-        session.knockouts_count = sum(hand.hero_ko_this_hand for hand in ft_hands_in_session)
+        session.knockouts_count = sum(
+            hand.hero_ko_this_hand for hand in ft_hands_in_session
+        )
 
         # Среднее место по всем турнирам в сессии
-        all_places_session = [t.finish_place for t in tournaments_in_session if t.finish_place is not None]
-        session.avg_finish_place = sum(all_places_session) / len(all_places_session) if all_places_session else 0.0
+        all_places_session = [
+            t.finish_place for t in tournaments_in_session if t.finish_place is not None
+        ]
+        session.avg_finish_place = (
+            sum(all_places_session) / len(all_places_session)
+            if all_places_session
+            else 0.0
+        )
 
-        session.total_prize = sum(t.payout for t in tournaments_in_session if t.payout is not None)
-        session.total_buy_in = sum(t.buyin for t in tournaments_in_session if t.buyin is not None)
+        session.total_prize = sum(
+            t.payout for t in tournaments_in_session if t.payout is not None
+        )
+        session.total_buy_in = sum(
+            t.buyin for t in tournaments_in_session if t.buyin is not None
+        )
 
         # Округляем значения
         session.avg_finish_place = round(session.avg_finish_place, 2)
         session.total_prize = round(session.total_prize, 2)
         session.total_buy_in = round(session.total_buy_in, 2)
 
-        logger.debug(f"Сессия {session_id}: турниров={session.tournaments_count}, KO={session.knockouts_count}, avg_place={session.avg_finish_place}, prize={session.total_prize}, buyin={session.total_buy_in}")
+        logger.debug(
+            f"Сессия {session_id}: турниров={session.tournaments_count}, KO={session.knockouts_count}, avg_place={session.avg_finish_place}, prize={session.total_prize}, buyin={session.total_buy_in}"
+        )
         self.session_repo.update_session_stats(session)
-
 
     # --- Методы для получения данных для UI ---
 
@@ -803,9 +1082,29 @@ class ApplicationService:
         """Возвращает объект OverallStats с общей статистикой."""
         return self.overall_stats_repo.get_overall_stats()
 
-    def get_all_tournaments(self, buyin_filter: Optional[float] = None) -> List[Tournament]:
+    def get_all_tournaments(
+        self, buyin_filter: Optional[float] = None
+    ) -> List[Tournament]:
         """Возвращает список всех турниров Hero, опционально фильтруя по бай-ину."""
         return self.tournament_repo.get_all_tournaments(buyin_filter=buyin_filter)
+
+    def get_tournaments_page(
+        self,
+        page: int,
+        page_size: int,
+        buyin_filter: Optional[float] = None,
+    ) -> List[Tournament]:
+        """Возвращает страницу турниров для ленивой загрузки в UI."""
+        offset = (page - 1) * page_size
+        return self.tournament_repo.get_tournaments_page(
+            limit=page_size,
+            offset=offset,
+            buyin_filter=buyin_filter,
+        )
+
+    def count_all_tournaments(self, buyin_filter: Optional[float] = None) -> int:
+        """Возвращает общее количество турниров."""
+        return self.tournament_repo.count_all(buyin_filter=buyin_filter)
 
     def get_all_sessions(self) -> List[Session]:
         """Возвращает список всех сессий Hero."""
@@ -843,21 +1142,23 @@ class ApplicationService:
         return self.session_repo.get_session_by_id(session_id)
 
     def get_place_distribution_for_session(self, session_id: str) -> Dict[int, int]:
-         """
-         Рассчитывает и возвращает распределение мест (1-9) только для турниров в указанной сессии.
-         """
-         tournaments_in_session = self.tournament_repo.get_all_tournaments(session_id=session_id)
-         distribution = {i: 0 for i in range(1, 10)}
-         total_final_tables_in_session = 0
+        """
+        Рассчитывает и возвращает распределение мест (1-9) только для турниров в указанной сессии.
+        """
+        tournaments_in_session = self.tournament_repo.get_all_tournaments(
+            session_id=session_id
+        )
+        distribution = {i: 0 for i in range(1, 10)}
+        total_final_tables_in_session = 0
 
-         for tourney in tournaments_in_session:
-              if tourney.reached_final_table:
-                   total_final_tables_in_session += 1 # Count FTs for this session
-                   if tourney.finish_place is not None and 1 <= tourney.finish_place <= 9:
-                        distribution[tourney.finish_place] += 1
+        for tourney in tournaments_in_session:
+            if tourney.reached_final_table:
+                total_final_tables_in_session += 1  # Count FTs for this session
+                if tourney.finish_place is not None and 1 <= tourney.finish_place <= 9:
+                    distribution[tourney.finish_place] += 1
 
-         # Возвращаем распределение и общее количество финалок в сессии для нормализации в UI
-         return distribution, total_final_tables_in_session
+        # Возвращаем распределение и общее количество финалок в сессии для нормализации в UI
+        return distribution, total_final_tables_in_session
 
     def delete_session(self, session_id: str):
         """Удаляет сессию и все связанные данные."""

--- a/ui/tournament_view.py
+++ b/ui/tournament_view.py
@@ -8,97 +8,133 @@ from PyQt6 import QtWidgets, QtCore, QtGui
 import logging
 from typing import List, Optional
 
-from ui.app_style import setup_table_widget, format_money, apply_cell_color_by_value, format_percentage
+from ui.app_style import (
+    setup_table_widget,
+    format_money,
+    apply_cell_color_by_value,
+    format_percentage,
+)
 from application_service import ApplicationService
 from models import Tournament
 from ui.background import thread_manager
 
-logger = logging.getLogger('ROYAL_Stats.TournamentView')
+logger = logging.getLogger("ROYAL_Stats.TournamentView")
 logger.setLevel(logging.DEBUG)
 
 
 class TournamentView(QtWidgets.QWidget):
     """Виджет для отображения списка турниров с фильтрами."""
-    
+
     def __init__(self, app_service: ApplicationService, parent=None):
         super().__init__(parent)
         self.app_service = app_service
         self.tournaments: List[Tournament] = []
         self._data_cache = {}  # Кеш для данных
         self._cache_valid = False  # Флаг валидности кеша
+        self.PAGE_SIZE = 100
+        self.current_page = 1
+        self.total_tournaments = 0
+        self._loading = False
         self._init_ui()
-        
+
+    def _get_current_buyin_filter(self) -> Optional[float]:
+        text = self.buyin_filter.currentText()
+        if text and text != "Все":
+            try:
+                return float(text.replace("$", "").replace(",", ""))
+            except ValueError:
+                return None
+        return None
+
     def _init_ui(self):
         """Инициализирует интерфейс."""
         self.main_layout = QtWidgets.QVBoxLayout(self)
         self.main_layout.setContentsMargins(16, 16, 16, 16)
-        
+
         # Контейнер для содержимого
         self.content_widget = QtWidgets.QWidget()
         content_layout = QtWidgets.QVBoxLayout(self.content_widget)
         content_layout.setContentsMargins(0, 0, 0, 0)
-        
+
         # Заголовок
         header = QtWidgets.QLabel("Список турниров")
-        header.setStyleSheet("""
+        header.setStyleSheet(
+            """
             QLabel {
                 font-size: 20px;
                 font-weight: bold;
                 color: #FAFAFA;
                 margin-bottom: 16px;
             }
-        """)
+        """
+        )
         content_layout.addWidget(header)
-        
+
         # Панель фильтров
         filter_layout = QtWidgets.QHBoxLayout()
         filter_layout.setSpacing(12)
-        
+
         # Фильтр по бай-ину
         filter_layout.addWidget(QtWidgets.QLabel("Бай-ин:"))
         self.buyin_filter = QtWidgets.QComboBox()
         self.buyin_filter.setMinimumWidth(120)
-        self.buyin_filter.currentTextChanged.connect(self._apply_filters)
+        self.buyin_filter.currentTextChanged.connect(self._on_buyin_filter_changed)
         filter_layout.addWidget(self.buyin_filter)
-        
+
         # Фильтр по результату
         filter_layout.addWidget(QtWidgets.QLabel("Результат:"))
         self.result_filter = QtWidgets.QComboBox()
         self.result_filter.setMinimumWidth(150)
-        self.result_filter.addItems(["Все", "В призах (1-3)", "Финальный стол", "Вне призов"])
+        self.result_filter.addItems(
+            ["Все", "В призах (1-3)", "Финальный стол", "Вне призов"]
+        )
         self.result_filter.currentTextChanged.connect(self._apply_filters)
         filter_layout.addWidget(self.result_filter)
-        
+
         filter_layout.addStretch()
-        
+
         # Информация о фильтрации
         self.filter_info = QtWidgets.QLabel("")
         self.filter_info.setStyleSheet("color: #A1A1AA; font-size: 13px;")
         filter_layout.addWidget(self.filter_info)
-        
+
         content_layout.addLayout(filter_layout)
-        
+
         # Таблица турниров
         self.table = QtWidgets.QTableWidget()
         self.table.setColumnCount(8)
-        self.table.setHorizontalHeaderLabels([
-            "ID турнира", "Название", "Дата", "Бай-ин", 
-            "Место", "Выплата", "KO", "Профит"
-        ])
-        
+        self.table.setHorizontalHeaderLabels(
+            [
+                "ID турнира",
+                "Название",
+                "Дата",
+                "Бай-ин",
+                "Место",
+                "Выплата",
+                "KO",
+                "Профит",
+            ]
+        )
+
         setup_table_widget(self.table)
-        
+
         # Настройка ширины колонок
         header = self.table.horizontalHeader()
-        header.setSectionResizeMode(0, QtWidgets.QHeaderView.ResizeMode.ResizeToContents)
+        header.setSectionResizeMode(
+            0, QtWidgets.QHeaderView.ResizeMode.ResizeToContents
+        )
         header.setSectionResizeMode(1, QtWidgets.QHeaderView.ResizeMode.Stretch)
-        header.setSectionResizeMode(2, QtWidgets.QHeaderView.ResizeMode.ResizeToContents)
-        
+        header.setSectionResizeMode(
+            2, QtWidgets.QHeaderView.ResizeMode.ResizeToContents
+        )
+
         content_layout.addWidget(self.table)
-        
+        self.table.verticalScrollBar().valueChanged.connect(self._check_scroll_position)
+
         # Статистика внизу
         self.stats_label = QtWidgets.QLabel("")
-        self.stats_label.setStyleSheet("""
+        self.stats_label.setStyleSheet(
+            """
             QLabel {
                 color: #E4E4E7;
                 font-size: 14px;
@@ -107,43 +143,49 @@ class TournamentView(QtWidgets.QWidget):
                 border-radius: 8px;
                 margin-top: 8px;
             }
-        """)
+        """
+        )
         content_layout.addWidget(self.stats_label)
-        
+
         self.main_layout.addWidget(self.content_widget)
-        
+
         # Создаем loading overlay
         self._create_loading_overlay()
-        
+
     def _create_loading_overlay(self):
         """Создает оверлей загрузки."""
         self.loading_overlay = QtWidgets.QWidget(self)
-        self.loading_overlay.setStyleSheet("""
+        self.loading_overlay.setStyleSheet(
+            """
             QWidget {
                 background-color: rgba(0, 0, 0, 0.7);
             }
-        """)
-        
+        """
+        )
+
         layout = QtWidgets.QVBoxLayout(self.loading_overlay)
-        
+
         # Контейнер для индикатора
         container = QtWidgets.QWidget()
         container.setMaximumWidth(300)
-        container.setStyleSheet("""
+        container.setStyleSheet(
+            """
             QWidget {
                 background-color: #27272A;
                 border-radius: 12px;
                 padding: 20px;
             }
-        """)
-        
+        """
+        )
+
         container_layout = QtWidgets.QVBoxLayout(container)
-        
+
         # Индикатор загрузки
         self.progress_bar = QtWidgets.QProgressBar()
         self.progress_bar.setRange(0, 0)  # Неопределенный прогресс
         self.progress_bar.setTextVisible(False)
-        self.progress_bar.setStyleSheet("""
+        self.progress_bar.setStyleSheet(
+            """
             QProgressBar {
                 background-color: #3F3F46;
                 border-radius: 6px;
@@ -153,72 +195,90 @@ class TournamentView(QtWidgets.QWidget):
                 background-color: #3B82F6;
                 border-radius: 6px;
             }
-        """)
+        """
+        )
         container_layout.addWidget(self.progress_bar)
-        
+
         # Текст загрузки
         self.loading_label = QtWidgets.QLabel("Загрузка турниров...")
-        self.loading_label.setStyleSheet("""
+        self.loading_label.setStyleSheet(
+            """
             QLabel {
                 color: #FAFAFA;
                 font-size: 16px;
                 font-weight: bold;
                 margin-top: 10px;
             }
-        """)
+        """
+        )
         self.loading_label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
         container_layout.addWidget(self.loading_label)
-        
+
         layout.addWidget(container, alignment=QtCore.Qt.AlignmentFlag.AlignCenter)
-        
+
         self.loading_overlay.hide()
-        
+
     def show_loading_overlay(self):
         """Показывает оверлей загрузки."""
         self.loading_overlay.resize(self.size())
         self.loading_overlay.raise_()
         self.loading_overlay.show()
-        
+
     def hide_loading_overlay(self):
         """Скрывает оверлей загрузки."""
         self.loading_overlay.hide()
-        
+
     def resizeEvent(self, event):
         """Обрабатывает изменение размера виджета."""
         super().resizeEvent(event)
         # Обновляем размер оверлея при изменении размера виджета
-        if hasattr(self, 'loading_overlay'):
+        if hasattr(self, "loading_overlay"):
             self.loading_overlay.resize(self.size())
-            
+
     def invalidate_cache(self):
         """Сбрасывает кеш данных."""
         self._cache_valid = False
         self._data_cache.clear()
-        
+
     def reload(self, show_overlay: bool = True):
-        """Перезагружает данные из ApplicationService."""
+        """Загружает первую страницу турниров."""
         logger.debug("Перезагрузка TournamentView...")
+        self.current_page = 1
+        self.tournaments = []
+        self.total_tournaments = 0
         self._show_overlay = show_overlay
         if show_overlay:
             self.show_loading_overlay()
+
         def load_data():
-            tournaments = self.app_service.get_all_tournaments()
+            buyin_filter = self._get_current_buyin_filter()
+            count = self.app_service.count_all_tournaments(buyin_filter=buyin_filter)
+            tournaments = self.app_service.get_tournaments_page(
+                self.current_page,
+                self.PAGE_SIZE,
+                buyin_filter=buyin_filter,
+            )
             buyins = self.app_service.get_distinct_buyins()
-            return tournaments, buyins
+            return tournaments, buyins, count
+
         thread_manager.run_in_thread(
             widget_id=str(id(self)),
             fn=load_data,
             callback=self._on_data_loaded,
-            error_callback=lambda e: logger.error(f"Ошибка загрузки данных TournamentView: {e}"),
-            owner=self
+            error_callback=lambda e: logger.error(
+                f"Ошибка загрузки данных TournamentView: {e}"
+            ),
+            owner=self,
         )
+
     def _on_data_loaded(self, data):
-        """Применяет загруженные данные к UI."""
-        tournaments, buyins = data
+        """Обрабатывает данные первой страницы."""
+        tournaments, buyins, count = data
         try:
-            self.tournaments = tournaments
-            self._data_cache['tournaments'] = tournaments
-            self._data_cache['buyins'] = buyins
+            self.total_tournaments = count
+            self.tournaments.extend(tournaments)
+            self._data_cache["tournaments"] = self.tournaments
+            self._data_cache["buyins"] = buyins
             self._cache_valid = True
             self._update_buyin_filter()
             self._apply_filters()
@@ -226,42 +286,55 @@ class TournamentView(QtWidgets.QWidget):
         finally:
             if getattr(self, "_show_overlay", False):
                 self.hide_loading_overlay()
-            
+
     def _load_data(self):
         """Загружает данные из ApplicationService в кеш."""
         logger.debug("Загрузка данных в кеш TournamentView...")
-        
-        # Загружаем все турниры
-        self.tournaments = self.app_service.get_all_tournaments()
-        self._data_cache['tournaments'] = self.tournaments
-        
+
+        self.current_page = 1
+        buyin_filter = self._get_current_buyin_filter()
+        self.tournaments = self.app_service.get_tournaments_page(
+            self.current_page, self.PAGE_SIZE, buyin_filter=buyin_filter
+        )
+        self.total_tournaments = self.app_service.count_all_tournaments(
+            buyin_filter=buyin_filter
+        )
+        self._data_cache["tournaments"] = self.tournaments
+
         # Загружаем уникальные бай-ины
-        self._data_cache['buyins'] = self.app_service.get_distinct_buyins()
-        
+        self._data_cache["buyins"] = self.app_service.get_distinct_buyins()
+
         logger.debug(f"Загружено {len(self.tournaments)} турниров")
-        
+
     def _update_buyin_filter(self):
         """Обновляет список доступных бай-инов."""
         current_text = self.buyin_filter.currentText()
+        self.buyin_filter.blockSignals(True)
         self.buyin_filter.clear()
-        
+
         # Получаем уникальные бай-ины из кеша
-        buyins = self._data_cache.get('buyins', [])
-        
+        buyins = self._data_cache.get("buyins", [])
+
         # Добавляем "Все" и отсортированные бай-ины
         self.buyin_filter.addItem("Все")
         for buyin in sorted(buyins):
             self.buyin_filter.addItem(format_money(buyin, decimals=0))
-            
+
         # Восстанавливаем выбор, если возможно
         index = self.buyin_filter.findText(current_text)
         if index >= 0:
             self.buyin_filter.setCurrentIndex(index)
-            
+        self.buyin_filter.blockSignals(False)
+
+    def _on_buyin_filter_changed(self, _):
+        """Перезагружает данные при изменении фильтра бай-ина."""
+        self.invalidate_cache()
+        self.reload()
+
     def _apply_filters(self):
         """Применяет выбранные фильтры к списку турниров."""
         logger.debug("Применение фильтров в TournamentView...")
-        
+
         # Фильтрация по бай-ину
         buyin_text = self.buyin_filter.currentText()
         if buyin_text and buyin_text != "Все":
@@ -273,46 +346,53 @@ class TournamentView(QtWidgets.QWidget):
                 filtered = self.tournaments
         else:
             filtered = self.tournaments[:]
-            
+
         # Фильтрация по результату
         result_text = self.result_filter.currentText()
         if result_text == "В призах (1-3)":
-            filtered = [t for t in filtered if t.finish_place and 1 <= t.finish_place <= 3]
+            filtered = [
+                t for t in filtered if t.finish_place and 1 <= t.finish_place <= 3
+            ]
         elif result_text == "Финальный стол":
             filtered = [t for t in filtered if t.reached_final_table]
         elif result_text == "Вне призов":
             filtered = [t for t in filtered if t.finish_place and t.finish_place > 3]
-            
+
         # Обновляем таблицу
         self._update_tournaments_table(filtered)
-        
+
         # Обновляем информацию о фильтрации
-        self.filter_info.setText(f"Показано: {len(filtered)} из {len(self.tournaments)}")
-        
+        self.filter_info.setText(
+            f"Показано: {len(filtered)} из {self.total_tournaments}"
+        )
+
         # Обновляем статистику
         self._update_statistics(filtered)
-        
+
     def _update_tournaments_table(self, tournaments: List[Tournament]):
         """Обновляет таблицу турниров."""
         self.table.setRowCount(len(tournaments))
-        
+
         for row, t in enumerate(tournaments):
             # ID турнира
             self.table.setItem(row, 0, QtWidgets.QTableWidgetItem(t.tournament_id))
-            
+
             # Название
             name = t.tournament_name or "-"
             self.table.setItem(row, 1, QtWidgets.QTableWidgetItem(name))
-            
+
             # Дата
             date = t.start_time or "-"
             self.table.setItem(row, 2, QtWidgets.QTableWidgetItem(date))
-            
+
             # Бай-ин
             buyin_item = QtWidgets.QTableWidgetItem(format_money(t.buyin, decimals=0))
-            buyin_item.setTextAlignment(QtCore.Qt.AlignmentFlag.AlignRight | QtCore.Qt.AlignmentFlag.AlignVCenter)
+            buyin_item.setTextAlignment(
+                QtCore.Qt.AlignmentFlag.AlignRight
+                | QtCore.Qt.AlignmentFlag.AlignVCenter
+            )
             self.table.setItem(row, 3, buyin_item)
-            
+
             # Место
             place_text = str(t.finish_place) if t.finish_place else "-"
             place_item = QtWidgets.QTableWidgetItem(place_text)
@@ -326,43 +406,55 @@ class TournamentView(QtWidgets.QWidget):
                 elif t.finish_place == 3:
                     place_item.setForeground(QtGui.QBrush(QtGui.QColor("#FCD34D")))
             self.table.setItem(row, 4, place_item)
-            
+
             # Выплата
             payout_item = QtWidgets.QTableWidgetItem(format_money(t.payout))
-            payout_item.setTextAlignment(QtCore.Qt.AlignmentFlag.AlignRight | QtCore.Qt.AlignmentFlag.AlignVCenter)
+            payout_item.setTextAlignment(
+                QtCore.Qt.AlignmentFlag.AlignRight
+                | QtCore.Qt.AlignmentFlag.AlignVCenter
+            )
             apply_cell_color_by_value(payout_item, t.payout)
             self.table.setItem(row, 5, payout_item)
-            
+
             # KO
             ko_item = QtWidgets.QTableWidgetItem(str(t.ko_count))
             ko_item.setTextAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
             if t.ko_count > 0:
                 ko_item.setForeground(QtGui.QBrush(QtGui.QColor("#10B981")))
             self.table.setItem(row, 6, ko_item)
-            
+
             # Профит
-            profit = (t.payout if t.payout is not None else 0) - (t.buyin if t.buyin is not None else 0)
-            profit_item = QtWidgets.QTableWidgetItem(format_money(profit, with_plus=True))
-            profit_item.setTextAlignment(QtCore.Qt.AlignmentFlag.AlignRight | QtCore.Qt.AlignmentFlag.AlignVCenter)
+            profit = (t.payout if t.payout is not None else 0) - (
+                t.buyin if t.buyin is not None else 0
+            )
+            profit_item = QtWidgets.QTableWidgetItem(
+                format_money(profit, with_plus=True)
+            )
+            profit_item.setTextAlignment(
+                QtCore.Qt.AlignmentFlag.AlignRight
+                | QtCore.Qt.AlignmentFlag.AlignVCenter
+            )
             apply_cell_color_by_value(profit_item, profit)
             self.table.setItem(row, 7, profit_item)
-            
+
     def _update_statistics(self, tournaments: List[Tournament]):
         """Обновляет статистику для отфильтрованных турниров."""
         if not tournaments:
             self.stats_label.setText("Нет турниров для отображения")
             return
-            
+
         total = len(tournaments)
         total_buyin = sum(t.buyin for t in tournaments if t.buyin is not None)
         total_payout = sum(t.payout if t.payout is not None else 0 for t in tournaments)
         total_profit = total_payout - total_buyin
         total_ko = sum(t.ko_count for t in tournaments)
-        itm_count = sum(1 for t in tournaments if t.finish_place and 1 <= t.finish_place <= 3)
+        itm_count = sum(
+            1 for t in tournaments if t.finish_place and 1 <= t.finish_place <= 3
+        )
         itm_percent = (itm_count / total * 100) if total > 0 else 0
-        
+
         roi = ((total_profit / total_buyin) * 100) if total_buyin > 0 else 0
-        
+
         self.stats_label.setText(
             f"Турниров: {total} | "
             f"Бай-ин: {format_money(total_buyin)} | "
@@ -372,3 +464,43 @@ class TournamentView(QtWidgets.QWidget):
             f"ITM: {itm_percent:.1f}% | "
             f"KO: {total_ko}"
         )
+
+    def _check_scroll_position(self, value: int):
+        scrollbar = self.table.verticalScrollBar()
+        if value >= scrollbar.maximum() - 2:
+            self.load_next_page()
+
+    def load_next_page(self):
+        if self._loading:
+            return
+        if len(self.tournaments) >= self.total_tournaments:
+            return
+        self._loading = True
+        self.show_loading_overlay()
+        next_page = self.current_page + 1
+
+        def load():
+            buyin_filter = self._get_current_buyin_filter()
+            return self.app_service.get_tournaments_page(
+                next_page, self.PAGE_SIZE, buyin_filter=buyin_filter
+            )
+
+        thread_manager.run_in_thread(
+            widget_id=f"{id(self)}_page_{next_page}",
+            fn=load,
+            callback=lambda data: self._on_next_page_loaded(next_page, data),
+            error_callback=lambda e: logger.error(
+                f"Ошибка загрузки страницы турниров: {e}"
+            ),
+            owner=self,
+        )
+
+    def _on_next_page_loaded(self, page: int, tournaments: List[Tournament]):
+        try:
+            self.current_page = page
+            self.tournaments.extend(tournaments)
+            self._data_cache["tournaments"] = self.tournaments
+            self._apply_filters()
+        finally:
+            self.hide_loading_overlay()
+            self._loading = False


### PR DESCRIPTION
## Summary
- add repository method for page-based tournament loading
- expose pagination methods in `ApplicationService`
- update `TournamentView` with lazy loading and buy-in filter reload

## Testing
- `python -m py_compile $(git ls-files '*.py')`
