### PR TITLE
Fix big blind parser for numbers with comma

### DIFF
--- a/parsers/hand_history.py
+++ b/parsers/hand_history.py
@@ -281,7 +281,11 @@ class HandHistoryParser(BaseParser):
                 
             m_blinds = RE_BLINDS_HEADER.search(line)
             if m_blinds:
-                bb = float(m_blinds.group(2).replace(',', '.'))
+                # Значение BB может содержать разделители тысяч вида "1,000".
+                # Заменяем запятую на пустую строку, чтобы корректно обработать
+                # как значения "0.5", так и "1,000" → 1000.0
+                bb_str = m_blinds.group(2).replace(',', '')
+                bb = float(bb_str)
                 
             m_seat = RE_SEAT.match(line)
             if m_seat:


### PR DESCRIPTION
## Summary
- handle big blind numbers like `1,000` correctly

## Testing
- `python - <<'PY'
from parsers.hand_history import HandHistoryParser
parser = HandHistoryParser()
with open('hh_examples/GG20250518-1756 - 11 - 0.5 - 1 - 9max.txt', encoding='utf-8') as f:
    txt = f.read()
res = parser.parse(txt, 'sample')
print('tournament_id:', res.get('tournament_id'))
for h in res['final_table_hands_data']:
    if h['hand_id'] == 'BR731172182':
        print(h['bb'])
        break
PY