### PR TITLE
Fix missing final table hands

### DIFF
--- a/parsers/hand_history.py
+++ b/parsers/hand_history.py
@@ -448,12 +448,13 @@ class HandHistoryParser(BaseParser):
                 pl = NAME(m_action.group('player_name'))
                 act = m_action.group('action')
                 amt_str = m_action.group(3) if len(m_action.groups()) > 2 else None
-                amt = CHIP(amt_str) if amt_str else 0
-                
+
                 if act in ('posts', 'bets', 'calls', 'all-in'):
+                    amt = CHIP(amt_str) if amt_str else 0
                     contrib[pl] = contrib.get(pl, 0) + amt
                     street_contrib[pl] = street_contrib.get(pl, 0) + amt
                 elif act == 'raises':
+                    amt = CHIP(amt_str) if amt_str else 0
                     # Пример: "d16ad03f: raises 2,846 to 3,146"
                     # В GG Poker это значит: рейз ДО 3,146 (total amount)
                     m_raise_to = RE_RAISE_TO.search(line)


### PR DESCRIPTION
## Summary
- ensure hand history parser handles `shows` lines correctly
- previously numbers inside card names caused a conversion error, skipping some hands

## Testing
- `python - <<'PY'
import parsers.hand_history as hh, config
text=open('hh_examples/GG20250518-1756 - 11 - 0.5 - 1 - 9max.txt').read()
res=hh.HandHistoryParser(config.HERO_NAME).parse(text)
print(len(res['final_table_hands_data']))
print('BR731171830' in [d['hand_id'] for d in res['final_table_hands_data']])
PY`
- `python - <<'PY'
import parsers.hand_history as hh, config
text=open('hh_examples/GG20250515-2115 - 11 - 0.15 - 0.3 - 9max.txt').read()
res=hh.HandHistoryParser(config.HERO_NAME).parse(text)
print(len(res['final_table_hands_data']))
print('BR728335476' in [d['hand_id'] for d in res['final_table_hands_data']])
PY`
