### PR TITLE
Persist overall stats cache

### DIFF
--- a/config.py
+++ b/config.py
@@ -20,6 +20,8 @@ DB_PATH = os.path.join(DEFAULT_DB_DIR, DEFAULT_DB_NAME)
 
 # Файл для хранения последней выбранной БД
 LAST_DB_FILE = os.path.join(DEFAULT_DB_DIR, "last_db_path.txt")
+# Файл для хранения кеша статистики по базам данных
+STATS_CACHE_FILE = os.path.join(DEFAULT_DB_DIR, "stats_cache.json")
 
 # Последняя открытая БД
 if os.path.exists(LAST_DB_FILE):


### PR DESCRIPTION
## Notes
- Config now defines `STATS_CACHE_FILE` used for persistent stats cache.
- `ApplicationService` loads/saves the cache on disk and validates it using an MD5 checksum of the DB file.
- Stats cache is updated whenever statistics are recalculated.


------
https://chatgpt.com/codex/tasks/task_e_683aaa209bf88323bc4dced9a7a70e76