### PR TITLE
Fix GUI freeze after import

### DIFF
--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -281,7 +281,17 @@ class MainWindow(QtWidgets.QMainWindow):
     def _import_finished(self):
         """Вызывается по завершении потока импорта."""
         logger.info("Поток импорта завершен.")
-        # progress_dialog закроется автоматически если autoClose=True
+        # Без гарантированного закрытия прогресс-диалога иногда возникал
+        # сценарий, когда диалог оставался открытым из-за ошибки в потоке
+        # импорта и блокировал главный цикл событий. Поэтому дополнительно
+        # закрываем диалог принудительно.
+        if hasattr(self, "progress_dialog") and self.progress_dialog:
+            self.progress_dialog.close()
+            self.progress_dialog.deleteLater()
+            self.progress_dialog = None
+
+        # progress_dialog обычно закрывается автоматически, но принудительное
+        # закрытие выше страхует от зависания интерфейса.
         
         # По завершении импорта сразу обновляем UI
         self._update_toolbar_info()


### PR DESCRIPTION
## Summary
- close progress dialog explicitly when import thread finishes
- avoid hanging nested event loop if progress dialog fails to close automatically

## Testing
- `pre-commit` *(fails: missing configuration)*

------
https://chatgpt.com/codex/tasks/task_e_683ab47522688323be7444fb5c2aee45