### PR TITLE
Fix stats recalculation by skipping redundant DB updates

### DIFF
--- a/application_service.py
+++ b/application_service.py
@@ -710,12 +710,13 @@ class ApplicationService:
         # --- Обновление Place Distribution ---
         try:
             logger.debug("Обновление распределения мест...")
-            self.place_dist_repo.reset_distribution()
+            new_distribution = {i: 0 for i in range(1, 10)}
             for tourney in all_final_tournaments:
-                self.place_dist_repo.increment_place_count(tourney.finish_place)
+                new_distribution[tourney.finish_place] += 1
                 current_step += 1
                 if progress_callback:
                     progress_callback(current_step, total_steps, f"Обновлено мест: {current_step-1}/{len(all_final_tournaments)}")
+            self.place_dist_repo.update_distribution(new_distribution)
             logger.info(f"Распределение мест обновлено для {len(all_final_tournaments)} турниров.")
         except Exception as e:
             logger.error(f"Ошибка при обновлении place_distribution: {e}")

--- a/db/repositories/overall_stats_repo.py
+++ b/db/repositories/overall_stats_repo.py
@@ -37,7 +37,23 @@ class OverallStatsRepository:
         Обновляет агрегированную статистику Hero.
         Принимает объект OverallStats с уже подсчитанными агрегатами.
         Обновляет только запись с id=1.
+        Если новые значения совпадают с уже сохранёнными, обновление не
+        выполняется. Это предотвращает лишние изменения файла БД и,
+        соответственно, изменение его контрольной суммы.
         """
+
+        # Получаем текущие значения, чтобы сравнить с новыми
+        current = self.get_overall_stats()
+
+        def _strip(stats_obj: OverallStats) -> dict:
+            data = stats_obj.as_dict()
+            data.pop("last_updated", None)
+            data.pop("id", None)
+            return data
+
+        if _strip(current) == _strip(stats):
+            return
+
         query = """
             UPDATE overall_stats
             SET

--- a/db/repositories/place_distribution_repo.py
+++ b/db/repositories/place_distribution_repo.py
@@ -45,6 +45,19 @@ class PlaceDistributionRepository:
         query = "UPDATE places_distribution SET count = count + 1 WHERE place = ?"
         self.db.execute_update(query, (place,))
 
+    def update_distribution(self, distribution: Dict[int, int]):
+        """
+        Обновляет распределение мест, изменяя только отличающиеся значения.
+        Используется при пересчёте статистики, чтобы не трогать БД,
+        если распределение не изменилось.
+        """
+        current = self.get_distribution()
+        for place in range(1, 10):
+            new_count = distribution.get(place, 0)
+            if current.get(place, 0) != new_count:
+                query = "UPDATE places_distribution SET count = ? WHERE place = ?"
+                self.db.execute_update(query, (new_count, place))
+
     def reset_distribution(self):
         """
         Сбрасывает все счетчики распределения мест в 0.

--- a/db/repositories/session_repo.py
+++ b/db/repositories/session_repo.py
@@ -52,7 +52,23 @@ class SessionRepository:
         """
         Обновляет агрегированную статистику для существующей сессии.
         Принимает объект Session с уже подсчитанными агрегатами.
+        Если значения статистики не изменились, обновление не выполняется,
+        чтобы не менять файл базы данных лишний раз.
         """
+
+        current = self.get_session_by_id(session.session_id)
+        if current:
+            def _strip(s: Session) -> dict:
+                data = s.as_dict()
+                # Поля session_name и created_at не меняются при обновлении
+                data.pop("id", None)
+                data.pop("session_name", None)
+                data.pop("created_at", None)
+                return data
+
+            if _strip(current) == _strip(session):
+                return
+
         query = """
             UPDATE sessions
             SET

--- a/db/repositories/tournament_repo.py
+++ b/db/repositories/tournament_repo.py
@@ -35,7 +35,19 @@ class TournamentRepository:
         Использует ON CONFLICT для upsert.
         Логика мерджа данных из HH и TS происходит в ApplicationService,
         сюда приходит уже подготовленный объект Tournament.
+        Если значения всех полей не изменились, обновление пропускается,
+        чтобы избежать лишних модификаций базы.
         """
+
+        existing = self.get_tournament_by_id(tournament.tournament_id)
+        if existing:
+            def _strip(t: Tournament) -> dict:
+                data = t.as_dict()
+                data.pop("id", None)
+                return data
+
+            if _strip(existing) == _strip(tournament):
+                return
         query = """
             INSERT INTO tournaments (
                 tournament_id, tournament_name, start_time, buyin, payout,


### PR DESCRIPTION
## Summary
- avoid rewriting aggregated stats if values didn't change
- skip session and tournament updates when they are identical
- update place distribution only when counts change
- compute distribution in memory before updating

## Testing
- `python -m py_compile db/repositories/overall_stats_repo.py db/repositories/session_repo.py db/repositories/tournament_repo.py db/repositories/place_distribution_repo.py application_service.py`

------
https://chatgpt.com/codex/tasks/task_e_683abeb431c883238a4822aebc7669b5