### PR TITLE
Fix import cancel

### DIFF
--- a/application_service.py
+++ b/application_service.py
@@ -300,8 +300,18 @@ class ApplicationService:
 
         total_candidates = 0
         for path in paths:
+            if is_canceled_callback and is_canceled_callback():
+                logger.info("Импорт отменен пользователем при подсчете файлов.")
+                if progress_callback:
+                    progress_callback(0, 0, "Импорт отменен пользователем")
+                return
             if os.path.isdir(path):
                 for _, _, filenames in os.walk(path):
+                    if is_canceled_callback and is_canceled_callback():
+                        logger.info("Импорт отменен пользователем при подсчете файлов.")
+                        if progress_callback:
+                            progress_callback(0, 0, "Импорт отменен пользователем")
+                        return
                     total_candidates += len([f for f in filenames if f.lower().endswith(".txt")])
             elif os.path.isfile(path) and path.lower().endswith(".txt"):
                 total_candidates += 1
@@ -310,9 +320,19 @@ class ApplicationService:
         filtered_files_count = 0
         processed_candidates = 0
         for path in paths:
+            if is_canceled_callback and is_canceled_callback():
+                logger.info("Импорт отменен пользователем при подготовке файлов.")
+                if progress_callback:
+                    progress_callback(processed_candidates, total_candidates, "Импорт отменен пользователем")
+                return
             if os.path.isdir(path):
                 for root, _, filenames in os.walk(path):
                     for fname in filenames:
+                        if is_canceled_callback and is_canceled_callback():
+                            logger.info("Импорт отменен пользователем при подготовке файлов.")
+                            if progress_callback:
+                                progress_callback(processed_candidates, total_candidates, "Импорт отменен пользователем")
+                            return
                         if fname.lower().endswith(".txt"):
                             full_path = os.path.join(root, fname)
                             if is_poker_file(full_path):
@@ -323,6 +343,11 @@ class ApplicationService:
                             if progress_callback and total_candidates:
                                 progress_callback(processed_candidates, total_candidates, "Подготовка файлов...")
             elif os.path.isfile(path) and path.lower().endswith(".txt"):
+                if is_canceled_callback and is_canceled_callback():
+                    logger.info("Импорт отменен пользователем при подготовке файлов.")
+                    if progress_callback:
+                        progress_callback(processed_candidates, total_candidates, "Импорт отменен пользователем")
+                    return
                 if is_poker_file(path):
                     all_files_to_process.append(path)
                 else:

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -289,8 +289,14 @@ class MainWindow(QtWidgets.QMainWindow):
         if self.import_thread and self.import_thread.isRunning():
             # Используем безопасный метод отмены через флаг
             self.import_thread.cancel()
-            # Обновляем диалог прогресса
-            self.progress_dialog.setLabelText("Отмена импорта, пожалуйста подождите...")
+            # Отключаем обновление прогресса, чтобы диалог не появлялся снова
+            try:
+                self.import_progress_signal.disconnect(self._update_progress)
+            except TypeError:
+                pass
+            # Закрываем диалог, чтобы он не показывался снова
+            if self.progress_dialog:
+                self.progress_dialog.close()
             self.statusBar().showMessage("Импорт отменен пользователем", 3000)
 
     @QtCore.pyqtSlot()


### PR DESCRIPTION
## Notes
- Added checks in `ApplicationService.import_files` to exit early when the user cancels during file preparation.
- Updated `MainWindow._cancel_import` to close the progress dialog and disconnect progress updates so it does not reappear.

## Summary
- allow canceling file preparation stage
- keep progress dialog closed after cancel

------
https://chatgpt.com/codex/tasks/task_e_683ac6660ec88323bc89913a820bef01