### PR TITLE
Add final table stack column and copy ID option

### DIFF
--- a/db/repositories/tournament_repo.py
+++ b/db/repositories/tournament_repo.py
@@ -447,12 +447,12 @@ class TournamentRepository:
         page_size = max(1, min(500, page_size))
         allowed_sort_columns = {
             "tournament_id": "tournament_id",
-            "tournament_name": "tournament_name", 
             "start_time": "start_time",
             "buyin": "buyin",
             "finish_place": "finish_place",
             "payout": "payout",
             "ko_count": "ko_count",
+            "final_table_initial_stack_chips": "final_table_initial_stack_chips",
             "profit": "(COALESCE(payout, 0) - COALESCE(buyin, 0))"
         }
         if sort_column not in allowed_sort_columns:


### PR DESCRIPTION
## Summary
- update tournaments table columns: remove name, add start stack
- support date formatting and copy tournament ID via context menu
- allow sorting by final table stack in repo

## Testing
- `pytest -q` *(fails: ImportError libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_683ac5a04764832391aee74cf14889d7