### PR TITLE
Fix UI freeze when switching databases

### DIFF
--- a/ui/database_management_dialog.py
+++ b/ui/database_management_dialog.py
@@ -251,12 +251,13 @@ class DatabaseManagementDialog(QtWidgets.QDialog):
         """Выбирает БД и закрывает диалог."""
         if self.selected_db_path and self.selected_db_path != self.app_service.db_path:
             try:
-                self.app_service.switch_database(self.selected_db_path)
+                # Загружаем новую БД без синхронного пересчёта статистики
+                self.app_service.switch_database(self.selected_db_path, load_stats=False)
                 self.accept()
             except Exception as e:
                 QtWidgets.QMessageBox.critical(
-                    self, 
-                    "Ошибка", 
+                    self,
+                    "Ошибка",
                     f"Не удалось переключиться на базу данных:\n{e}"
                 )
         else:

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -200,13 +200,12 @@ class MainWindow(QtWidgets.QMainWindow):
         if dialog.exec():  # Модальное исполнение
             new_path = self.app_service.db_path
             if new_path != current_path:
+                # Отменяем все фоновые операции перед сменой БД
+                thread_manager.cancel_all()
                 config.set_db_path(new_path)
-                # Загружаем/пересчитываем статистику для новой БД
-                self.app_service.ensure_overall_stats_cached()
-                # Инвалидируем кеши и обновляем все представления
+                # Сбрасываем кеши и запускаем асинхронную загрузку данных
                 self.invalidate_all_caches()
-                self.refresh_all_views(force_all=True)
-                self._update_toolbar_info()
+                self.refresh_all_data()
             self._update_db_label()
             self.statusBar().showMessage(
                 f"Подключена база данных: {os.path.basename(self.app_service.db_path)}"


### PR DESCRIPTION
## Summary
- avoid heavy sync stats loading when switching DBs
- start async refresh and cancel running threads first
- load DB without stats in DB management dialog

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683ada77796c8323b72becd7b88dd221