### PR TITLE
Add KO x10 frequency info label

### DIFF
--- a/ui/stats_grid.py
+++ b/ui/stats_grid.py
@@ -360,10 +360,29 @@ class StatsGrid(QtWidgets.QWidget):
             'x1000': StatCard("KO x1000", "-"),
             'x10000': StatCard("KO x10000", "-"),
         }
-        
+
+        # Текст с информацией о частоте KO x10
+        self.bigko_x10_info_label = QtWidgets.QLabel("")
+        self.bigko_x10_info_label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+        self.bigko_x10_info_label.setStyleSheet(
+            "QLabel { color: #A1A1AA; font-size: 10px; }"
+        )
+
+        # Контейнер для карточки x10 и текста над ней
+        x10_container = QtWidgets.QVBoxLayout()
+        x10_container.setSpacing(1)
+        x10_container.addWidget(self.bigko_x10_info_label)
+        x10_container.addWidget(self.bigko_cards['x10'])
+        x10_widget = QtWidgets.QWidget()
+        x10_widget.setLayout(x10_container)
+
         # Добавляем все карточки Big KO в горизонтальный layout
-        for key in ['x1.5', 'x2', 'x10', 'x100', 'x1000', 'x10000']:
-            bigko_layout.addWidget(self.bigko_cards[key])
+        bigko_layout.addWidget(self.bigko_cards['x1.5'])
+        bigko_layout.addWidget(self.bigko_cards['x2'])
+        bigko_layout.addWidget(x10_widget)
+        bigko_layout.addWidget(self.bigko_cards['x100'])
+        bigko_layout.addWidget(self.bigko_cards['x1000'])
+        bigko_layout.addWidget(self.bigko_cards['x10000'])
             
         content_layout.addLayout(bigko_layout)
         
@@ -802,6 +821,14 @@ class StatsGrid(QtWidgets.QWidget):
                 self.bigko_cards['x10000'].value_label,
                 overall_stats.big_ko_x10000,
             )
+            # Обновляем текст над карточкой KO x10
+            if overall_stats.big_ko_x10 > 0:
+                per_tourn = overall_stats.total_tournaments / overall_stats.big_ko_x10
+                per_ko = overall_stats.total_knockouts / overall_stats.big_ko_x10 if overall_stats.total_knockouts > 0 else 0
+                info_text = f"1 на {per_tourn:.0f} турниров\n1 к {per_ko:.0f} нокаутов"
+            else:
+                info_text = "нет"
+            self.bigko_x10_info_label.setText(info_text)
             logger.debug(f"Обновлены карточки Big KO: x1.5={overall_stats.big_ko_x1_5}, x2={overall_stats.big_ko_x2}, x10={overall_stats.big_ko_x10}, x100={overall_stats.big_ko_x100}, x1000={overall_stats.big_ko_x1000}, x10000={overall_stats.big_ko_x10000}")
             
             # Обновляем стат KO Luck


### PR DESCRIPTION
## Summary
- show how often we hit KO x10 right above the KO x10 card

## Testing
- `pytest -q` *(fails: ImportError: libEGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_683addafc6448323be5d0edec2cc9e6b