### PR TITLE
Fix toolbar stats update when filtering dashboard

### DIFF
--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -9,7 +9,7 @@ from PyQt6 import QtWidgets, QtGui, QtCore
 import sys
 import os
 import logging
-from typing import List
+from typing import List, Optional
 from datetime import datetime
 
 import config
@@ -24,6 +24,7 @@ from ui.session_view import SessionView
 from ui.session_select_dialog import SessionSelectDialog
 from ui.custom_icons import CustomIcons  # Импортируем кастомные иконки
 from ui.background import thread_manager
+from models import OverallStats
 
 # Импортируем диалог управления БД
 from ui.database_management_dialog import DatabaseManagementDialog # Предполагаем, что такой файл будет создан
@@ -168,6 +169,7 @@ class MainWindow(QtWidgets.QMainWindow):
         # Передаем им ApplicationService или ссылки на репозитории через ApplicationService
         # Лучше передавать сам ApplicationService, чтобы Views могли запрашивать у него данные
         self.stats_grid = StatsGrid(self.app_service)
+        self.stats_grid.overallStatsChanged.connect(self._update_toolbar_info)
         self.tournament_view = TournamentView(self.app_service)
         self.session_view = SessionView(self.app_service)
 
@@ -443,9 +445,10 @@ class MainWindow(QtWidgets.QMainWindow):
         )
 
 
-    def _update_toolbar_info(self):
+    def _update_toolbar_info(self, stats: Optional[OverallStats] = None):
         """Обновляет информационные Label в панели инструментов."""
-        stats = self.app_service.get_overall_stats()
+        if stats is None:
+            stats = self.app_service.get_overall_stats()
         self.total_tournaments_label.setText(f"Турниров: {stats.total_tournaments}")
         self.total_profit_label.setText(f"Прибыль: {format_money(stats.total_prize - stats.total_buy_in, with_plus=True)}")
         apply_cell_color_by_value(self.total_profit_label, stats.total_prize - stats.total_buy_in) # Применяем цвет

--- a/ui/stats_grid.py
+++ b/ui/stats_grid.py
@@ -196,6 +196,8 @@ class SpecialStatCard(QtWidgets.QFrame):
 
 class StatsGrid(QtWidgets.QWidget):
     """Виджет с сеткой статистических показателей и графиками."""
+
+    overallStatsChanged = QtCore.pyqtSignal(OverallStats)
     
     def __init__(self, app_service: ApplicationService, parent=None):
         super().__init__(parent)
@@ -870,11 +872,12 @@ class StatsGrid(QtWidgets.QWidget):
             self.cards['incomplete_ft'].update_value(f"{incomplete_percent}%")
             logger.debug(f"Обновлена карточка incomplete_ft: {incomplete_percent}%")
             
-            self.place_dist_ft = data['place_dist']
-            self.place_dist_pre_ft = data.get('place_dist_pre_ft', {})
-            self.place_dist_all = data.get('place_dist_all', {})
-            self._update_chart(self._get_current_distribution())
-            logger.debug("=== Конец reload StatsGrid ===")
+        self.place_dist_ft = data['place_dist']
+        self.place_dist_pre_ft = data.get('place_dist_pre_ft', {})
+        self.place_dist_all = data.get('place_dist_all', {})
+        self._update_chart(self._get_current_distribution())
+        self.overallStatsChanged.emit(overall_stats)
+        logger.debug("=== Конец reload StatsGrid ===")
 
         finally:
             # Скрываем индикатор загрузки


### PR DESCRIPTION
## Summary
- emit signal with filtered stats when stats grid reloads
- connect to update toolbar info in main window
- allow `_update_toolbar_info` to accept optional stats parameter

## Testing
- `python -m pytest -q` *(fails: ImportError: libEGL.so.1)*
- `python -m unittest discover tests` *(fails: ImportError: module 'config' has no attribute 'DEBUG')*

------
https://chatgpt.com/codex/tasks/task_e_683ade392c848323a827cdd52833cd03