### PR TITLE
Fix delete session argument

### DIFF
--- a/ui/session_view.py
+++ b/ui/session_view.py
@@ -350,7 +350,7 @@ class SessionView(QtWidgets.QWidget):
         if reply == QtWidgets.QMessageBox.StandardButton.Yes:
             self.show_loading_overlay()
             self.loading_label.setText("Удаление сессии...")
-            def delete_session():
+            def delete_session(is_cancelled_callback=None):
                 self.app_service.delete_session(session.session_id)
                 self.app_service._update_all_statistics(None)
                 return session.session_name


### PR DESCRIPTION
## Notes
- No tests were provided

## Summary
- accept optional `is_cancelled_callback` in `_delete_session()` helper so thread manager does not raise unexpected argument error

------
https://chatgpt.com/codex/tasks/task_e_683b3ab97b188323ad3adbac293a2bfa