### PR TITLE
Добавлено переименование сессии и упрощён UI

### DIFF
--- a/application_service.py
+++ b/application_service.py
@@ -1086,6 +1086,10 @@ class ApplicationService:
         self.session_repo.delete_session_by_id(session_id)
         # Статистика пересчитывается асинхронно во внешнем потоке
 
+    def rename_session(self, session_id: str, new_name: str):
+        """Переименовывает сессию."""
+        self.session_repo.update_session_name(session_id, new_name)
+
 
 # Создаем синглтон экземпляр ApplicationService
 application_service = ApplicationService()

--- a/db/repositories/session_repo.py
+++ b/db/repositories/session_repo.py
@@ -89,6 +89,11 @@ class SessionRepository:
         )
         self.db.execute_update(query, params)
 
+    def update_session_name(self, session_id: str, new_name: str):
+        """Обновляет название сессии."""
+        query = "UPDATE sessions SET session_name = ? WHERE session_id = ?"
+        self.db.execute_update(query, (new_name, session_id))
+
     def get_session_by_id(self, session_id: str) -> Optional[Session]:
         """
         Получает агрегированную инфу по одной сессии Hero по session_id.


### PR DESCRIPTION
## Summary
- убрана кнопка "Удалить сессию" под таблицей
- в контекстном меню таблицы сессий добавлено действие переименования
- пункт показа турниров удалён из меню
- реализована логика переименования сессии в репозитории и сервисе

## Testing
- `pytest -q` *(ошибка: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_683c16972f2483238b9b0102e5ac094b