### PR TITLE
update filters on session rename

### DIFF
--- a/ui/session_view.py
+++ b/ui/session_view.py
@@ -317,6 +317,13 @@ class SessionView(QtWidgets.QWidget):
                 self.app_service.rename_session(session.session_id, new_name)
                 self.invalidate_cache()
                 self.reload(show_overlay=False)
+                # После переименования обновляем связанные представления,
+                # чтобы новое название появилось в фильтрах других вкладок.
+                main_window = self.window()
+                if hasattr(main_window, "invalidate_all_caches") and hasattr(main_window, "refresh_all_views"):
+                    main_window.invalidate_all_caches()
+                    # Обновляем все вкладки без показа оверлея загрузки
+                    main_window.refresh_all_views(show_overlay=False, force_all=True)
             except Exception as e:
                 QtWidgets.QMessageBox.critical(self, "Ошибка", f"Не удалось переименовать сессию:\n{str(e)}")
         


### PR DESCRIPTION
## Summary
- refresh all views when a session is renamed so the filter combo boxes update automatically

## Testing
- `pytest -q` *(fails: ImportError: libEGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_683c1a4f95bc8323b406e58a9de4c201