### PR TITLE
Add KO contribution stat

### DIFF
--- a/stats/ko_contribution.py
+++ b/stats/ko_contribution.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+"""
+Плагин для расчета вклада нокаутов в общие выплаты.
+"""
+
+from typing import Dict, Any, List
+from .base import BaseStat
+from models import Tournament
+from config import BUYIN_AVG_KO_MAP
+
+
+class KOContributionStat(BaseStat):
+    """Возвращает долю выплат, полученных за нокауты."""
+
+    name = "KO Contribution"
+    description = "Доля выплат за нокауты (факт / adj)"
+
+    def compute(
+        self,
+        tournaments: List[Tournament],
+        final_table_hands: List[Any],
+        sessions: List[Any],
+        overall_stats: Any,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Возвращает фактический и скорректированный вклад нокаутов."""
+        if not tournaments:
+            return {"ko_contribution": 0.0, "ko_contribution_adj": 0.0}
+
+        regular = {1: 4.0, 2: 3.0, 3: 2.0}
+        total_payout = 0.0
+        regular_sum = 0.0
+        expected_ko = 0.0
+
+        for t in tournaments:
+            payout = t.payout or 0.0
+            buyin = t.buyin or 0.0
+            total_payout += payout
+            if t.finish_place in regular:
+                regular_sum += regular[t.finish_place] * buyin
+            if buyin in BUYIN_AVG_KO_MAP and t.ko_count > 0:
+                expected_ko += t.ko_count * BUYIN_AVG_KO_MAP[buyin]
+
+        ko_payout = total_payout - regular_sum
+        actual = (ko_payout / total_payout * 100.0) if total_payout > 0 else 0.0
+        denom = expected_ko + regular_sum
+        adj = (expected_ko / denom * 100.0) if denom > 0 else 0.0
+
+        return {
+            "ko_contribution": round(actual, 2),
+            "ko_contribution_adj": round(adj, 2),
+        }


### PR DESCRIPTION
## Summary
- implement new `KOContributionStat` plugin calculating actual and adjusted knockout payout share
- show new KO contribution card in stats grid

## Testing
- `python -m py_compile stats/ko_contribution.py ui/stats_grid.py`

------
https://chatgpt.com/codex/tasks/task_e_683c22b8dff48323ae4735deef9c089d