### PR TITLE
Fix date filter format

### DIFF
--- a/ui/stats_grid.py
+++ b/ui/stats_grid.py
@@ -749,8 +749,10 @@ class StatsGrid(QtWidgets.QWidget):
             tournaments = self.app_service.tournament_repo.get_all_tournaments(
                 session_id=self.current_session_id,
                 buyin_filter=self.current_buyin_filter,
-                start_time_from=self.current_date_from.strftime("%Y-%m-%d %H:%M:%S"),
-                start_time_to=self.current_date_to.strftime("%Y-%m-%d %H:%M:%S"),
+                # В БД дата хранится в формате "YYYY/MM/DD HH:MM:SS", поэтому
+                # формируем строки фильтра аналогично, чтобы сравнение прошло корректно
+                start_time_from=self.current_date_from.strftime("%Y/%m/%d %H:%M:%S"),
+                start_time_to=self.current_date_to.strftime("%Y/%m/%d %H:%M:%S"),
             )
             
             # Проверяем отмену после загрузки турниров

--- a/ui/tournament_view.py
+++ b/ui/tournament_view.py
@@ -353,8 +353,10 @@ class TournamentView(QtWidgets.QWidget):
                 result_filter=result_filter,
                 sort_column=self.sort_column,
                 sort_direction=self.sort_direction,
-                start_time_from=self.current_date_from.strftime("%Y-%m-%d %H:%M:%S"),
-                start_time_to=self.current_date_to.strftime("%Y-%m-%d %H:%M:%S"),
+                # Фильтр дат сравнивается со строкой вида "YYYY/MM/DD HH:MM:SS" в БД,
+                # поэтому здесь формируем такую же строку
+                start_time_from=self.current_date_from.strftime("%Y/%m/%d %H:%M:%S"),
+                start_time_to=self.current_date_to.strftime("%Y/%m/%d %H:%M:%S"),
             )
         thread_manager.run_in_thread(
             widget_id=f"{id(self)}_tournaments",


### PR DESCRIPTION
## Notes
- The date filter in the UI used a `strftime` pattern with dashes. The database
  stores `start_time` using slashes, so filters always returned zero rows.
- Updated both StatsGrid and TournamentView to output date strings in
  `YYYY/MM/DD HH:MM:SS` format before passing them to the repository.

## Summary
- format filter dates with slashes to match DB strings

------
https://chatgpt.com/codex/tasks/task_e_683c7a7f35ec8323b5ebe513bc3992da