### PR TITLE
Update DB dialog to refresh stats automatically

### DIFF
--- a/ui/database_management_dialog.py
+++ b/ui/database_management_dialog.py
@@ -295,6 +295,10 @@ class DatabaseManagementDialog(QtWidgets.QDialog):
                     "Успех",
                     f"База данных '{name}' успешно создана и выбрана."
                 )
+
+                # Закрываем диалог, чтобы основное окно сразу обновило статистику
+                # (MainWindow.compare db_path и вызовет refresh_all_data)
+                self.accept()
                 
             except Exception as e:
                 QtWidgets.QMessageBox.critical(


### PR DESCRIPTION
## Summary
- close `DatabaseManagementDialog` after creating a new database so MainWindow refreshes stats immediately

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683e9f594d58832392c8cb01dec7d963