### PR TITLE
Implement FT stack conversion stat

### DIFF
--- a/stats/ft_stack_conversion.py
+++ b/stats/ft_stack_conversion.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+"""Статистика эффективности конверсии стека в ранние KO на финальном столе."""
+
+from typing import Dict, Any, List
+from statistics import median
+
+from .base import BaseStat
+from models import Tournament, OverallStats
+import config
+
+
+class FTStackConversionStat(BaseStat):
+    """Примерная оценка конверсии стартового стека в ранние KO."""
+
+    name: str = "FT Stack Conversion"
+    description: str = (
+        "Отношение фактических ранних KO к ожидаемым,\n"
+        "рассчитанным из медианного стека на FT"
+    )
+
+    def compute(
+        self,
+        tournaments: List[Tournament],
+        final_table_hands: List[Any],
+        sessions: List[Any],
+        overall_stats: OverallStats,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        if not tournaments and not overall_stats:
+            return {"ft_stack_conversion": 0.0}
+
+        if overall_stats and hasattr(overall_stats, "early_ft_ko_per_tournament"):
+            early_ko_per_tournament = overall_stats.early_ft_ko_per_tournament
+        else:
+            ft_tours = [t for t in tournaments if t.reached_final_table]
+            early_ko_count = sum(
+                h.hero_ko_this_hand for h in final_table_hands if h.is_early_final
+            )
+            count = len(ft_tours)
+            early_ko_per_tournament = early_ko_count / count if count else 0.0
+
+        stacks = [
+            t.final_table_initial_stack_bb
+            for t in tournaments
+            if t.reached_final_table and t.final_table_initial_stack_bb is not None
+        ]
+        if not stacks:
+            return {"ft_stack_conversion": 0.0}
+
+        median_stack = median(stacks)
+        avg_stack = sum(stacks) / len(stacks)
+        expected_ko = (median_stack / avg_stack) * (config.FINAL_TABLE_SIZE - 1)
+        efficiency = (
+            early_ko_per_tournament / expected_ko if expected_ko > 0 else 0.0
+        )
+
+        return {"ft_stack_conversion": round(efficiency, 2)}
+

--- a/ui/stats_grid.py
+++ b/ui/stats_grid.py
@@ -45,6 +45,7 @@ from stats import (
     AvgFTInitialStackStat,
     EarlyFTKOStat,
     EarlyFTBustStat,
+    FTStackConversionStat,
     AvgFinishPlaceStat,
     AvgFinishPlaceFTStat,
     AvgFinishPlaceNoFTStat,
@@ -336,6 +337,7 @@ class StatsGrid(QtWidgets.QWidget):
             'avg_ft_stack': SpecialStatCard("Средний стек проходки на FT", "-"),
             'early_ft_ko': SpecialStatCard("KO в ранней FT (6-9max)", "-"),
             'early_ft_bust': SpecialStatCard("Вылеты в ранней FT\n(6-9max)", "-"),
+            'ft_stack_conv': StatCard("Конверсия стека в KO", "-"),
             'avg_place_all': StatCard("Среднее место (все)", "-"),
             'avg_place_ft': StatCard("Среднее место (FT)", "-"),
             'avg_place_no_ft': StatCard("Среднее место (не FT)", "-"),
@@ -346,8 +348,9 @@ class StatsGrid(QtWidgets.QWidget):
         # Размещаем карточки в сетке (5 колонок)
         positions = [
             ('tournaments', 0, 0), ('roi', 0, 1), ('itm', 0, 2), ('knockouts', 0, 3), ('avg_ko', 0, 4),
-            ('ft_reach', 1, 0), ('avg_ft_stack', 1, 1), ('early_ft_ko', 1, 2), ('ko_contribution', 1, 3), ('pre_ft_ko', 1, 4),
+            ('ft_reach', 1, 0), ('avg_ft_stack', 1, 1), ('early_ft_ko', 1, 2), ('ft_stack_conv', 1, 3), ('pre_ft_ko', 1, 4),
             ('avg_place_all', 2, 0), ('avg_place_ft', 2, 1), ('avg_place_no_ft', 2, 2), ('early_ft_bust', 2, 3), ('incomplete_ft', 2, 4),
+            ('ko_contribution', 3, 0),
         ]
         
         for key, row, col in positions:
@@ -822,6 +825,8 @@ class StatsGrid(QtWidgets.QWidget):
             early_res = EarlyFTKOStat().compute(tournaments, ft_hands, [], overall_stats)
             early_ko = early_res.get('early_ft_ko_count', 0)
             early_ko_per = early_res.get('early_ft_ko_per_tournament', 0.0)
+            conv_res = FTStackConversionStat().compute(tournaments, ft_hands, [], overall_stats)
+            ft_stack_conv = conv_res.get('ft_stack_conversion', 0.0)
             pre_ft_ko_res = PreFTKOStat().compute(tournaments, ft_hands, [], overall_stats)
             pre_ft_ko_count = pre_ft_ko_res.get('pre_ft_ko_count', 0.0)
             
@@ -855,6 +860,7 @@ class StatsGrid(QtWidgets.QWidget):
                 'avg_bb': avg_bb,
                 'early_ko': early_ko,
                 'early_ko_per': early_ko_per,
+                'ft_stack_conv': ft_stack_conv,
                 'pre_ft_ko_count': pre_ft_ko_count,
                 'incomplete_ft_percent': incomplete_ft_percent,
                 'avg_place_all': avg_all,
@@ -935,6 +941,10 @@ class StatsGrid(QtWidgets.QWidget):
                 f"{early_ko_per:.2f} за турнир с FT"
             )
             logger.debug(f"Обновлена карточка early_ft_ko: {early_ko_count} / {early_ko_per:.2f}")
+
+            ft_stack_conv = data.get('ft_stack_conv', 0.0)
+            self.cards['ft_stack_conv'].update_value(f"{ft_stack_conv:.2f}")
+            logger.debug(f"Обновлена карточка ft_stack_conv: {ft_stack_conv:.2f}")
 
             bust_result = EarlyFTBustStat().compute(all_tournaments, [], [], overall_stats)
             logger.debug(f"Early FT Bust result: {bust_result}")


### PR DESCRIPTION
## Summary
- add `FTStackConversionStat` to estimate KO conversion from stack
- show new stat in stats grid UI

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683ec34fb3888323935f0b93f40c87f7