### PR TITLE
Fix median line persistence

### DIFF
--- a/ui/stats_grid.py
+++ b/ui/stats_grid.py
@@ -1307,12 +1307,33 @@ class StatsGrid(QtWidgets.QWidget):
         median_value = median(stack_values) if stack_values else None
 
         return ft_stack_dist, median_value
-        
+
+    def _clear_chart_overlays(self):
+        """Удаляет вспомогательные элементы (метки и медианную линию) с графика."""
+        current_chart = self.chart_view.chart()
+        if not current_chart:
+            return
+        for label in getattr(self.chart_view, "chart_labels", []):
+            try:
+                current_chart.scene().removeItem(label)
+            except Exception:
+                pass
+        self.chart_view.chart_labels = []
+        for line in getattr(self.chart_view, "median_lines", []):
+            try:
+                current_chart.scene().removeItem(line)
+            except Exception:
+                pass
+        self.chart_view.median_lines = []
+
     def _update_chart(self, place_dist=None):
         """Обновляет гистограмму распределения мест."""
         if place_dist is None:
             place_dist = self._get_current_distribution()
-        
+
+        # Удаляем элементы предыдущего графика, если они есть
+        self._clear_chart_overlays()
+
         # Проверяем, есть ли данные
         if not place_dist or all(count == 0 for count in place_dist.values()):
             logger.warning("Нет данных для построения гистограммы распределения мест")


### PR DESCRIPTION
## Summary
- clear chart overlays whenever a chart is updated
- ensure the median line does not remain on empty or other histograms

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6840225e95c88323b412e3406dfffe44