### PR TITLE
Adjust default x10 big KO color

### DIFF
--- a/ui/app_style.py
+++ b/ui/app_style.py
@@ -418,7 +418,7 @@ def apply_bigko_x10_color(label: QtWidgets.QLabel, total_tournaments: int, x10_c
     color = "#A1A1AA"
 
     if x10_count <= 0 or total_tournaments <= 0:
-        color = "#EF4444"  # Red when there were no x10 knockouts
+        color = "#FAFAFA"  # Default white when there were no x10 knockouts
     else:
         # Интервал может быть дробным. Приводим его к целому, чтобы не
         # возникало «дыр» между граничными значениями диапазонов.


### PR DESCRIPTION
## Summary
- keep the x10 Big KO stat white when no records are available

## Testing
- `No tests run due to user request`


------
https://chatgpt.com/codex/tasks/task_e_6841b0fd2c108323a1b44b7b2f0d2327