### PR TITLE
Исправление работы файла кэша статистики

### DIFF
--- a/application_service.py
+++ b/application_service.py
@@ -145,6 +145,9 @@ class ApplicationService:
 
         self.hh_parser = HandHistoryParser()
         self.ts_parser = TournamentSummaryParser()
+
+        # Загружаем кэш или создаём его при инициализации сервиса
+        self.ensure_overall_stats_cached()
         
     @property
     def tournament_repo(self):

--- a/config.py
+++ b/config.py
@@ -24,7 +24,9 @@ DB_PATH = os.path.join(DEFAULT_DB_DIR, DEFAULT_DB_NAME)
 # Файл для хранения последней выбранной БД
 LAST_DB_FILE = os.path.join(DEFAULT_DB_DIR, "last_db_path.txt")
 # Файл для хранения кеша статистики по базам данных
-STATS_CACHE_FILE = os.path.join(DEFAULT_DB_DIR, "stats_cache.json")
+STATS_CACHE_FILE = os.path.abspath(
+    os.path.join(DEFAULT_DB_DIR, "stats_cache.json")
+)
 
 # Последняя открытая БД
 if os.path.exists(LAST_DB_FILE):


### PR DESCRIPTION
## Summary
- гарантировать абсолютный путь для `stats_cache.json`
- создавать или загружать кэш сразу при инициализации `ApplicationService`

## Testing
- `python -m py_compile application_service.py config.py`
- `python - <<'PY'
from application_service import ApplicationService
import config
print('cache file path', config.STATS_CACHE_FILE)
app = ApplicationService()
print('cache keys', app._persistent_cache.keys())
PY`

------
https://chatgpt.com/codex/tasks/task_e_6841b8e95c5c83239ad58381847c64a1