### PR TITLE
Fix tournament refresh after import

### DIFF
--- a/ui/stats_grid.py
+++ b/ui/stats_grid.py
@@ -776,6 +776,10 @@ class StatsGrid(QtWidgets.QWidget):
     def reload(self, show_overlay: bool = True):
         """Перезагружает все данные из ApplicationService."""
         self._show_overlay = show_overlay
+        # Аналогично TournamentView обновляем верхнюю границу диапазона дат,
+        # чтобы статистика учитывала недавно добавленные турниры.
+        self.current_date_to = datetime.now()
+        self.date_to_edit.setDateTime(QtCore.QDateTime.currentDateTime())
         if show_overlay:
             self.show_loading_overlay()
 

--- a/ui/tournament_view.py
+++ b/ui/tournament_view.py
@@ -313,6 +313,11 @@ class TournamentView(QtWidgets.QWidget):
     def reload(self, show_overlay: bool = True):
         """Перезагружает данные из ApplicationService."""
         self._show_overlay = show_overlay
+        # При каждой перезагрузке обновляем дату "По" на текущее время,
+        # иначе новые турниры с временем старше предыдущего значения
+        # не будут отображаться, пока приложение не перезапустится.
+        self.current_date_to = datetime.now()
+        self.date_to_edit.setDateTime(QtCore.QDateTime.currentDateTime())
         if show_overlay:
             self.show_loading_overlay()
         def load_filter_data(is_cancelled_callback=None):


### PR DESCRIPTION
## Summary
- update 'To' date to current time on reload
- do the same for stats grid so stats include newest tournaments

## Testing
- `pytest -q` *(fails: HandHistoryResult missing methods, missing files)*

------
https://chatgpt.com/codex/tasks/task_e_684657d6e71c8323af5431d631639a8b