### PR TITLE
inject db manager into repositories

### DIFF
--- a/app.py
+++ b/app.py
@@ -78,12 +78,12 @@ class DependencyContainer:
         self.db_manager = database_manager
         self.db_manager.set_db_path(self.config.current_db_path)
         
-        # Создаем репозитории
-        self.tournament_repo = TournamentRepository()
-        self.session_repo = SessionRepository()
-        self.overall_stats_repo = OverallStatsRepository()
-        self.place_dist_repo = PlaceDistributionRepository()
-        self.ft_hand_repo = FinalTableHandRepository()
+        # Создаем репозитории, передавая единый менеджер БД
+        self.tournament_repo = TournamentRepository(self.db_manager)
+        self.session_repo = SessionRepository(self.db_manager)
+        self.overall_stats_repo = OverallStatsRepository(self.db_manager)
+        self.place_dist_repo = PlaceDistributionRepository(self.db_manager)
+        self.ft_hand_repo = FinalTableHandRepository(self.db_manager)
         
         # Создаем парсеры
         self.hh_parser = HandHistoryParser(self.config.hero_name)

--- a/application_service.py
+++ b/application_service.py
@@ -124,11 +124,11 @@ class ApplicationService:
 
     def __init__(self):
         self.db = database_manager
-        self._tournament_repo = TournamentRepository()
-        self.session_repo = SessionRepository()
-        self.overall_stats_repo = OverallStatsRepository()
-        self.place_dist_repo = PlaceDistributionRepository()
-        self.ft_hand_repo = FinalTableHandRepository()
+        self._tournament_repo = TournamentRepository(self.db)
+        self.session_repo = SessionRepository(self.db)
+        self.overall_stats_repo = OverallStatsRepository(self.db)
+        self.place_dist_repo = PlaceDistributionRepository(self.db)
+        self.ft_hand_repo = FinalTableHandRepository(self.db)
 
         # Кеш статистики по БД. Ключ - путь к БД, значение - OverallStats
         self._overall_stats_cache: Dict[str, OverallStats] = {}

--- a/db/repositories/base_repository.py
+++ b/db/repositories/base_repository.py
@@ -9,7 +9,7 @@ from abc import ABC, abstractmethod
 from typing import Optional, TypeVar, Generic, List, Any
 import logging
 
-from db.manager import database_manager
+from db.manager import DatabaseManager, database_manager
 
 logger = logging.getLogger('ROYAL_Stats.BaseRepository')
 
@@ -23,9 +23,9 @@ class BaseRepository(ABC, Generic[T]):
     Предоставляет общий функционал для работы с БД.
     """
     
-    def __init__(self):
+    def __init__(self, db_manager: DatabaseManager = database_manager):
         """Инициализация базового репозитория."""
-        self._db_manager = database_manager
+        self._db_manager = db_manager
         self._logger = logging.getLogger(f'ROYAL_Stats.{self.__class__.__name__}')
     
     @property

--- a/db/repositories/final_table_hand_repo.py
+++ b/db/repositories/final_table_hand_repo.py
@@ -7,7 +7,7 @@
 import sqlite3
 import logging
 from typing import List, Optional
-from db.manager import database_manager # Используем синглтон менеджер БД
+from db.manager import DatabaseManager, database_manager  # Используем синглтон менеджер БД
 from models import FinalTableHand
 import config
 
@@ -19,8 +19,8 @@ class FinalTableHandRepository:
     Репозиторий для хранения и получения данных раздач финального стола Hero.
     """
 
-    def __init__(self):
-        self.db = database_manager # Используем синглтон
+    def __init__(self, db_manager: DatabaseManager = database_manager):
+        self.db = db_manager  # Используем переданный менеджер
 
     def add_hand(self, hand: FinalTableHand):
         """

--- a/db/repositories/overall_stats_repo.py
+++ b/db/repositories/overall_stats_repo.py
@@ -5,7 +5,7 @@
 """
 
 from typing import Optional
-from db.manager import database_manager # Используем синглтон менеджер БД
+from db.manager import DatabaseManager, database_manager  # Используем синглтон менеджер БД
 from models import OverallStats
 from datetime import datetime # Импортируем для метки времени
 
@@ -15,8 +15,8 @@ class OverallStatsRepository:
     Предполагается, что таблица содержит ровно одну запись с id=1.
     """
 
-    def __init__(self):
-        self.db = database_manager # Используем синглтон
+    def __init__(self, db_manager: DatabaseManager = database_manager):
+        self.db = db_manager  # Используем переданный менеджер
 
     def get_overall_stats(self) -> OverallStats:
         """

--- a/db/repositories/place_distribution_repo.py
+++ b/db/repositories/place_distribution_repo.py
@@ -6,15 +6,15 @@
 
 import sqlite3
 from typing import Dict
-from db.manager import database_manager # Используем синглтон менеджер БД
+from db.manager import DatabaseManager, database_manager  # Используем синглтон менеджер БД
 
 class PlaceDistributionRepository:
     """
     Репозиторий для хранения и получения распределения мест Hero на финальном столе (1-9).
     """
 
-    def __init__(self):
-        self.db = database_manager # Используем синглтон
+    def __init__(self, db_manager: DatabaseManager = database_manager):
+        self.db = db_manager  # Используем переданный менеджер
 
     def get_distribution(self) -> Dict[int, int]:
         """

--- a/db/repositories/session_repo.py
+++ b/db/repositories/session_repo.py
@@ -7,7 +7,7 @@
 
 import uuid
 from typing import List, Optional
-from db.manager import database_manager # Используем синглтон менеджер БД
+from db.manager import DatabaseManager, database_manager  # Используем синглтон менеджер БД
 from models import Session
 
 class SessionRepository:
@@ -15,8 +15,8 @@ class SessionRepository:
     Репозиторий для хранения агрегированной инфы о сессиях Hero из таблицы sessions.
     """
 
-    def __init__(self):
-        self.db = database_manager # Используем синглтон
+    def __init__(self, db_manager: DatabaseManager = database_manager):
+        self.db = db_manager  # Используем переданный менеджер
 
     def create_session(self, session_name: str) -> Session:
         """
@@ -184,4 +184,4 @@ class SessionRepository:
         return stats
 
 # Создаем синглтон экземпляр репозитория
-session_repository = SessionRepository()
+session_repository = SessionRepository(database_manager)

--- a/db/repositories/tournament_repo.py
+++ b/db/repositories/tournament_repo.py
@@ -7,7 +7,7 @@
 
 import sqlite3
 from typing import List, Optional, Dict, Any, Tuple
-from db.manager import database_manager # Используем синглтон менеджер БД
+from db.manager import DatabaseManager, database_manager  # Используем синглтон менеджер БД
 from models import Tournament
 from dataclasses import dataclass
 
@@ -25,9 +25,9 @@ class TournamentRepository:
     Хранит и отдает инфу о турнирах только по Hero из таблицы tournaments.
     """
 
-    def __init__(self):
+    def __init__(self, db_manager: DatabaseManager = database_manager):
         # Репозитории работают с менеджером БД
-        self.db = database_manager # Используем синглтон
+        self.db = db_manager  # Используем переданный менеджер
 
     def add_or_update_tournament(self, tournament: Tournament):
         """
@@ -736,4 +736,4 @@ class TournamentRepository:
 
 
 # Создаем синглтон экземпляр репозитория
-tournament_repository = TournamentRepository()
+tournament_repository = TournamentRepository(database_manager)

--- a/services/app_facade.py
+++ b/services/app_facade.py
@@ -70,8 +70,8 @@ class AppFacade:
         self.statistics_service = statistics_service
         
         # Репозитории для прямого доступа к данным
-        self._tournament_repo = TournamentRepository()
-        self._session_repo = SessionRepository()
+        self._tournament_repo = TournamentRepository(db_manager)
+        self._session_repo = SessionRepository(db_manager)
         
         logger.info("AppFacade инициализирован")
     
@@ -455,14 +455,14 @@ class AppFacade:
         if buyin_filter is not None:
             # Если есть фильтр по байину, получаем список tournament_id
             tournament_ids = [t.tournament_id for t in tournaments]
-            ft_hand_repo = FinalTableHandRepository()
+            ft_hand_repo = FinalTableHandRepository(self.db_manager)
             ft_hands = ft_hand_repo.get_hands_by_filters(
                 session_id=session_id,
                 tournament_ids=tournament_ids if tournament_ids else None
             )
         else:
             # Если нет фильтра по байину, фильтруем только по сессии
-            ft_hand_repo = FinalTableHandRepository()
+            ft_hand_repo = FinalTableHandRepository(self.db_manager)
             ft_hands = ft_hand_repo.get_hands_by_filters(session_id=session_id)
         
         # Вычисляем общую статистику для отфильтрованных данных


### PR DESCRIPTION
## Summary
- add `db_manager` parameter for repositories
- pass single database manager in dependency container and services
- update facade to use the shared manager

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: FileNotFoundError & ImportErrors)*

------
https://chatgpt.com/codex/tasks/task_e_68468713a5e48323b5e2be4e3ed1df3a