### PR TITLE
Fix update statistics call after deletions

### DIFF
--- a/services/app_facade.py
+++ b/services/app_facade.py
@@ -345,6 +345,18 @@ class AppFacade:
             db_path=self.db_path,
             progress_callback=progress_callback
         )
+
+    def update_all_statistics(
+        self,
+        progress_callback: Optional[Callable[[int, int, str], None]] = None,
+    ):
+        """Пересчитывает всю статистику в текущей базе данных."""
+        self.statistics_service.update_all_statistics(
+            session_id="",
+            db_path=self.db_path,
+            progress_callback=progress_callback,
+            use_incremental=False,
+        )
     
     # === Управление данными ===
     

--- a/ui/session_view.py
+++ b/ui/session_view.py
@@ -346,7 +346,7 @@ class SessionView(QtWidgets.QWidget):
             self.loading_label.setText("Удаление сессии...")
             def delete_session(is_cancelled_callback=None):
                 self.app_service.delete_session(session.session_id)
-                self.app_service._update_all_statistics(None)
+                self.app_service.update_all_statistics(progress_callback=None)
                 return session.session_name
             thread_manager.run_in_thread(
                 widget_id=f"{id(self)}_delete",

--- a/ui/tournament_view.py
+++ b/ui/tournament_view.py
@@ -549,7 +549,7 @@ class TournamentView(QtWidgets.QWidget):
 
             def delete_tournament(is_cancelled_callback=None):
                 self.app_service.delete_tournament(tournament.tournament_id)
-                self.app_service._update_all_statistics(None)
+                self.app_service.update_all_statistics(progress_callback=None)
                 return tournament.tournament_id
 
             thread_manager.run_in_thread(


### PR DESCRIPTION
## Summary
- add `update_all_statistics` method to `AppFacade`
- call new method from session and tournament views when deleting items

## Testing
- `No tests run due to user request`

------
https://chatgpt.com/codex/tasks/task_e_684696ecb2a48323b36b31b9b138e4b6