### PR TITLE
Add init docstrings for repositories

### DIFF
--- a/db/repositories/final_table_hand_repo.py
+++ b/db/repositories/final_table_hand_repo.py
@@ -20,7 +20,8 @@ class FinalTableHandRepository:
     """
 
     def __init__(self):
-        self.db = database_manager # Используем синглтон
+        """Initialize repository with the shared database manager."""
+        self.db = database_manager  # Используем синглтон
 
     def add_hand(self, hand: FinalTableHand):
         """

--- a/db/repositories/overall_stats_repo.py
+++ b/db/repositories/overall_stats_repo.py
@@ -16,7 +16,8 @@ class OverallStatsRepository:
     """
 
     def __init__(self):
-        self.db = database_manager # Используем синглтон
+        """Initialize repository with the shared database manager."""
+        self.db = database_manager  # Используем синглтон
 
     def get_overall_stats(self) -> OverallStats:
         """

--- a/db/repositories/place_distribution_repo.py
+++ b/db/repositories/place_distribution_repo.py
@@ -14,7 +14,8 @@ class PlaceDistributionRepository:
     """
 
     def __init__(self):
-        self.db = database_manager # Используем синглтон
+        """Initialize repository with the shared database manager."""
+        self.db = database_manager  # Используем синглтон
 
     def get_distribution(self) -> Dict[int, int]:
         """

--- a/db/repositories/session_repo.py
+++ b/db/repositories/session_repo.py
@@ -16,7 +16,8 @@ class SessionRepository:
     """
 
     def __init__(self):
-        self.db = database_manager # Используем синглтон
+        """Initialize repository with the shared database manager."""
+        self.db = database_manager  # Используем синглтон
 
     def create_session(self, session_name: str) -> Session:
         """

--- a/db/repositories/tournament_repo.py
+++ b/db/repositories/tournament_repo.py
@@ -26,8 +26,9 @@ class TournamentRepository:
     """
 
     def __init__(self):
+        """Initialize repository with the shared database manager."""
         # Репозитории работают с менеджером БД
-        self.db = database_manager # Используем синглтон
+        self.db = database_manager  # Используем синглтон
 
     def add_or_update_tournament(self, tournament: Tournament):
         """


### PR DESCRIPTION
## Summary
- ensure repository constructors include short docstrings per PEP 257
- keep consistent quoting in new docstrings

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68465df0ae688323ab2f5d0b1b522fef