### PR TITLE
Fix stale stats display during refresh

### DIFF
--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -401,6 +401,8 @@ class MainWindow(QtWidgets.QMainWindow):
         """
         logger.info("Запуск полного обновления данных...")
         self._tab_loaded = {'stats': False, 'tournaments': False, 'sessions': False}
+        # Сбрасываем кеши сразу, чтобы избежать отображения устаревших данных
+        self.invalidate_all_caches()
         self._refresh_all_data_async(force_all=True)
 
     def _refresh_all_data_async(self, force_all: bool = False):

--- a/ui/stats_grid.py
+++ b/ui/stats_grid.py
@@ -778,6 +778,16 @@ class StatsGrid(QtWidgets.QWidget):
         """Сбрасывает кеш данных."""
         self._cache_valid = False
         self._data_cache.clear()
+        # Сбрасываем отображаемые значения карточек
+        for card in self.cards.values():
+            card.update_value("-")
+        for card in self.bigko_cards.values():
+            card.update_value("-")
+        # Очищаем график
+        self._clear_chart_overlays()
+        empty_chart = QChart()
+        empty_chart.setTheme(QChart.ChartTheme.ChartThemeDark)
+        self.chart_view.setChart(empty_chart)
         
     def reload(self, show_overlay: bool = True):
         """Перезагружает все данные через AppFacade."""


### PR DESCRIPTION
## Summary
- invalidate cached view data immediately when user triggers refresh
- reset StatsGrid UI to avoid showing stale numbers

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6846999aa3a88323a849c6cda208b4ca