### PR TITLE
Fix closing threads on app exit

### DIFF
--- a/ui/background.py
+++ b/ui/background.py
@@ -120,8 +120,11 @@ class ThreadManager:
                 # Увеличиваем время ожидания для больших операций
                 thread.wait(2000)  # Ждем максимум 2 секунды
                 if thread.isRunning():
-                    logger.warning(f"Поток {widget_id} не завершился, принудительное завершение")
+                    logger.warning(
+                        f"Поток {widget_id} не завершился, принудительное завершение"
+                    )
                     thread.terminate()  # Принудительное завершение
+                    thread.wait()  # Дожидаемся завершения после terminate
                     
     def _cleanup(self, widget_id: str):
         """Удаляет ссылки на завершенный поток."""


### PR DESCRIPTION
## Summary
- handle thread cleanup in MainWindow.closeEvent
- wait for terminated background threads

## Testing
- `pytest -q` *(fails: FinalTableHandRepository import issues)*

------
https://chatgpt.com/codex/tasks/task_e_68469b73f7248323aa059dbbab03dfad