### PR TITLE
Switch to AppConfig with config.ini

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,6 +15,7 @@ from ui.app_style import apply_dark_theme
 
 # Импорты для DI контейнера
 from services import (
+    app_config,
     AppConfig,
     AppFacade,
     ImportService,
@@ -81,14 +82,8 @@ class DependencyContainer:
         self.app_facade = self._create_app_facade()
     
     def _create_config(self) -> AppConfig:
-        """Создает конфигурацию приложения."""
-        try:
-            # Пытаемся создать из существующего config.py
-            return AppConfig.from_legacy_config()
-        except Exception:
-            # Если не удалось, создаем дефолтную
-            logger.warning("Не удалось загрузить legacy config, используем дефолтную конфигурацию")
-            return AppConfig()
+        """Возвращает глобальную конфигурацию приложения."""
+        return app_config
     
     def _create_import_service(self) -> ImportService:
         """Создает сервис импорта с зависимостями."""

--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,21 @@
+[game]
+hero_name = Hero
+final_table_size = 9
+early_ft_min_players = 6
+min_ko_blind_level_bb = 0
+
+[ko_coeff]
+8 = 0.40
+7 = 0.50
+6 = 0.60
+5 = 0.60
+4 = 0.65
+3 = 0.70
+2 = 0.70
+
+[buyin_avg_ko_map]
+0.25 = 0.23
+1.0 = 0.93
+3.0 = 2.79
+10.0 = 9.28
+25.0 = 23.18

--- a/db/manager.py
+++ b/db/manager.py
@@ -12,12 +12,12 @@ import logging
 import threading
 from typing import Optional, List, Dict, Any
 
-import config
+from services.app_config import app_config
 import db.schema # Импортируем схему для создания таблиц
 
 # Настройка логирования
 logger = logging.getLogger('ROYAL_Stats.Database')
-logger.setLevel(logging.DEBUG if config.DEBUG else logging.INFO)
+logger.setLevel(logging.DEBUG if app_config.debug else logging.INFO)
 
 class ThreadLocalConnection:
     """
@@ -101,14 +101,14 @@ class DatabaseManager:
     def __init__(self):
         """
         Инициализирует менеджер БД.
-        Путь к БД берется из config.DB_PATH при первом подключении.
+        Путь к БД берется из app_config.current_db_path при первом подключении.
         """
-        self._db_path = config.DB_PATH # Текущий активный путь к БД
+        self._db_path = app_config.current_db_path  # Текущий активный путь к БД
         self._conn_manager: Optional[ThreadLocalConnection] = None
         self._is_initialized = False # Флаг, показывающий, была ли инициализирована текущая БД
 
         # Убеждаемся, что папка для БД существует
-        os.makedirs(config.DEFAULT_DB_DIR, exist_ok=True)
+        os.makedirs(app_config.db_dir, exist_ok=True)
 
     @property
     def db_path(self) -> str:
@@ -126,7 +126,7 @@ class DatabaseManager:
             self._db_path = new_db_path
             self._conn_manager = None # Сбрасываем менеджер соединений
             self._is_initialized = False # Сбрасываем флаг инициализации
-            config.set_db_path(new_db_path) # Сохраняем новый путь в конфиг
+            app_config.set_current_db_path(new_db_path)  # Сохраняем новый путь в конфиг
 
 
     def get_connection(self) -> sqlite3.Connection:
@@ -226,18 +226,18 @@ class DatabaseManager:
         db_files = []
         try:
             # Проверяем существование директории
-            if os.path.exists(config.DEFAULT_DB_DIR) and os.path.isdir(config.DEFAULT_DB_DIR):
+            if os.path.exists(app_config.db_dir) and os.path.isdir(app_config.db_dir):
                 # Получаем список всех файлов с расширением .db
-                for file_name in os.listdir(config.DEFAULT_DB_DIR):
+                for file_name in os.listdir(app_config.db_dir):
                     if file_name.endswith('.db'):
-                        full_path = os.path.join(config.DEFAULT_DB_DIR, file_name)
+                        full_path = os.path.join(app_config.db_dir, file_name)
                         if os.path.isfile(full_path):
                             db_files.append(full_path)
                 
             else:
-                logger.warning(f"Директория {config.DEFAULT_DB_DIR} не существует или не является директорией")
+                logger.warning(f"Директория {app_config.db_dir} не существует или не является директорией")
                 # Создаем директорию, если она не существует
-                os.makedirs(config.DEFAULT_DB_DIR, exist_ok=True)
+                os.makedirs(app_config.db_dir, exist_ok=True)
         except Exception as e:
             logger.error(f"Ошибка при получении списка баз данных: {e}")
         

--- a/db/repositories/final_table_hand_repo.py
+++ b/db/repositories/final_table_hand_repo.py
@@ -9,7 +9,7 @@ import logging
 from typing import List, Optional
 from db.manager import DatabaseManager, database_manager  # Используем синглтон менеджер БД
 from models import FinalTableHand
-import config
+from services.app_config import app_config
 
 logger = logging.getLogger('ROYAL_Stats.FinalTableHandRepository')
 logger.setLevel(logging.DEBUG)
@@ -167,26 +167,24 @@ class FinalTableHandRepository:
         return [FinalTableHand.from_dict(dict(row)) for row in results]
 
     def get_first_final_table_hand_for_tournament(self, tournament_id: str) -> Optional[FinalTableHand]:
-         """
-         Возвращает первую раздачу 9-max стола (по hand_number) для указанного турнира.
-         Это соответствует старту финалки.
-         """
-         # Ищем раздачу с минимальным номером, которая является 9-max
-         # (полагаемся на то, что 9-max стол появляется один раз и с него начинается финалка)
-         query = """
+        """Возвращает первую раздачу 9-max стола для указанного турнира."""
+        query = """
             SELECT
                 id, tournament_id, hand_id, hand_number, table_size, bb,
                 hero_stack, players_count, hero_ko_this_hand, pre_ft_ko,
                 hero_ko_attempts, session_id, is_early_final
             FROM hero_final_table_hands
-             WHERE tournament_id = ? AND table_size = ? -- Ищем именно 9-max стол
-             ORDER BY hand_number ASC
-             LIMIT 1
-         """
-         result = self.db.execute_query(query, (tournament_id, config.FINAL_TABLE_SIZE))
-         if result:
-             return FinalTableHand.from_dict(dict(result[0]))
-         return None
+            WHERE tournament_id = ? AND table_size = ?
+            ORDER BY hand_number ASC
+            LIMIT 1
+        """
+        result = self.db.execute_query(
+            query,
+            (tournament_id, app_config.final_table_size)
+        )
+        if result:
+            return FinalTableHand.from_dict(dict(result[0]))
+        return None
     
     def get_ko_counts_for_tournaments(self, tournament_ids: List[str]) -> dict[str, float]:
         """

--- a/parsers/base_parser.py
+++ b/parsers/base_parser.py
@@ -6,7 +6,7 @@
 """
 from abc import ABC, abstractmethod
 from typing import Any, TypeVar, Generic
-import config  # Для имени Hero
+from services.app_config import app_config
 
 # Тип для результата парсера
 T = TypeVar('T')
@@ -18,7 +18,7 @@ class BaseParser(ABC, Generic[T]):
     Теперь типизирован для возврата конкретных моделей.
     """
 
-    def __init__(self, hero_name: str = config.HERO_NAME):
+    def __init__(self, hero_name: str = app_config.hero_name):
         # Имя Hero берется из конфигурации
         self.hero_name = hero_name
 

--- a/parsers/tournament_summary.py
+++ b/parsers/tournament_summary.py
@@ -10,12 +10,12 @@
 import re
 import logging
 from typing import Dict, Any, Optional
-import config
+from services.app_config import app_config
 from .base_parser import BaseParser # Наследуем от BaseParser
 from .parse_results import TournamentSummaryResult
 
 logger = logging.getLogger('ROYAL_Stats.TournamentSummaryParser')
-logger.setLevel(logging.DEBUG if config.DEBUG else logging.INFO)
+logger.setLevel(logging.DEBUG if app_config.debug else logging.INFO)
 
 
 class TournamentSummaryParser(BaseParser[TournamentSummaryResult]):
@@ -23,7 +23,7 @@ class TournamentSummaryParser(BaseParser[TournamentSummaryResult]):
     Парсер summary-файла турнира только для Hero.
     """
 
-    def __init__(self, hero_name: str = config.HERO_NAME):
+    def __init__(self, hero_name: str = app_config.hero_name):
         super().__init__(hero_name)
         # --- Регулярки для парсинга TS ---
         self.re_tournament_id_title = re.compile(r"Tournament #(\d+)") # Из заголовка (первая строка)

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -15,7 +15,7 @@ from .events import (
     TournamentDeletedEvent,
     CacheInvalidatedEvent
 )
-from .app_config import AppConfig
+from .app_config import AppConfig, app_config
 from .app_facade import AppFacade
 
 __all__ = [
@@ -31,5 +31,6 @@ __all__ = [
     'TournamentDeletedEvent',
     'CacheInvalidatedEvent',
     'AppConfig',
+    'app_config',
     'AppFacade',
 ]

--- a/stats/early_ft_bust.py
+++ b/stats/early_ft_bust.py
@@ -6,7 +6,7 @@
 from typing import Dict, Any, List
 from .base import BaseStat
 from models import Tournament, OverallStats
-import config
+from services.app_config import app_config
 
 
 class EarlyFTBustStat(BaseStat):
@@ -17,8 +17,8 @@ class EarlyFTBustStat(BaseStat):
     @property
     def description(self) -> str:
         return (
-            f"Количество вылетов Hero на ранней стадии финального стола ({config.EARLY_FT_MIN_PLAYERS}-"
-            f"{config.FINAL_TABLE_SIZE} место)"
+            f"Количество вылетов Hero на ранней стадии финального стола ({app_config.early_ft_min_players}-"
+            f"{app_config.final_table_size} место)"
         )
 
     def compute(
@@ -46,7 +46,7 @@ class EarlyFTBustStat(BaseStat):
                 for t in ft_tournaments
                 if (
                     t.finish_place is not None
-                    and config.EARLY_FT_MIN_PLAYERS <= t.finish_place <= config.FINAL_TABLE_SIZE
+                    and app_config.early_ft_min_players <= t.finish_place <= app_config.final_table_size
                 )
             )
             total_final_tables = len(ft_tournaments)

--- a/stats/ft_stack_conversion.py
+++ b/stats/ft_stack_conversion.py
@@ -6,7 +6,7 @@ from statistics import median
 
 from .base import BaseStat
 from models import Tournament, OverallStats
-import config
+from services.app_config import app_config
 
 
 class FTStackConversionStat(BaseStat):

--- a/stats/ft_stack_conversion_attempts.py
+++ b/stats/ft_stack_conversion_attempts.py
@@ -6,7 +6,7 @@ from statistics import median
 
 from .base import BaseStat
 from models import Tournament, OverallStats, FinalTableHand
-import config
+from services.app_config import app_config
 
 
 class FTStackConversionAttemptsStat(BaseStat):

--- a/stats/incomplete_ft_percent.py
+++ b/stats/incomplete_ft_percent.py
@@ -5,7 +5,7 @@
 
 from typing import Dict, Any, List
 
-import config
+from services.app_config import app_config
 from .base import BaseStat
 from models import Tournament, FinalTableHand, OverallStats
 
@@ -36,14 +36,14 @@ class IncompleteFTPercentStat(BaseStat):
 
         first_hands: dict[str, FinalTableHand] = {}
         for hand in final_table_hands:
-            if hand.table_size == config.FINAL_TABLE_SIZE:
+            if hand.table_size == app_config.final_table_size:
                 saved = first_hands.get(hand.tournament_id)
                 if saved is None or hand.hand_number < saved.hand_number:
                     first_hands[hand.tournament_id] = hand
 
         total_ft = len(first_hands)
         incomplete_count = sum(
-            1 for h in first_hands.values() if h.players_count < config.FINAL_TABLE_SIZE
+            1 for h in first_hands.values() if h.players_count < app_config.final_table_size
         )
         percent = int(round(incomplete_count / total_ft * 100)) if total_ft > 0 else 0
         return {"incomplete_ft_percent": percent}

--- a/stats/ko_contribution.py
+++ b/stats/ko_contribution.py
@@ -6,7 +6,7 @@
 from typing import Dict, Any, List
 from .base import BaseStat
 from models import Tournament
-from config import BUYIN_AVG_KO_MAP
+from services.app_config import app_config
 
 
 class KOContributionStat(BaseStat):
@@ -39,8 +39,8 @@ class KOContributionStat(BaseStat):
             total_payout += payout
             if t.finish_place in regular:
                 regular_sum += regular[t.finish_place] * buyin
-            if buyin in BUYIN_AVG_KO_MAP and t.ko_count > 0:
-                expected_ko += t.ko_count * BUYIN_AVG_KO_MAP[buyin]
+            if buyin in app_config.buyin_avg_ko_map and t.ko_count > 0:
+                expected_ko += t.ko_count * app_config.buyin_avg_ko_map[buyin]
 
         ko_payout = total_payout - regular_sum
         actual = (ko_payout / total_payout * 100.0) if total_payout > 0 else 0.0

--- a/ui/database_management_dialog.py
+++ b/ui/database_management_dialog.py
@@ -10,7 +10,6 @@ import os
 import logging
 from typing import Optional, List
 
-import config
 from services import AppFacade
 
 logger = logging.getLogger('ROYAL_Stats.DatabaseDialog')

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -12,7 +12,7 @@ import logging
 from typing import List, Optional
 from datetime import datetime
 
-import config
+from services.app_config import app_config
 # Импортируем типы для AppFacade
 from services import AppFacade
 
@@ -30,7 +30,7 @@ from models import OverallStats
 from ui.database_management_dialog import DatabaseManagementDialog # Предполагаем, что такой файл будет создан
 
 logger = logging.getLogger('ROYAL_Stats.MainWindow')
-logger.setLevel(logging.DEBUG if config.DEBUG else logging.INFO)
+logger.setLevel(logging.DEBUG if app_config.debug else logging.INFO)
 
 
 class MainWindow(QtWidgets.QMainWindow):
@@ -42,7 +42,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def __init__(self, app_facade: AppFacade):
         super().__init__()
-        self.setWindowTitle(config.APP_TITLE)
+        self.setWindowTitle(app_config.app_title)
         self.setMinimumSize(1300, 880)
 
         # Используем переданный AppFacade
@@ -61,13 +61,13 @@ class MainWindow(QtWidgets.QMainWindow):
     def _load_initial_data(self):
         """Подключает последнюю БД и запускает обновление статистики."""
         try:
-            self.app_service.switch_database(config.LAST_DB_PATH, load_stats=False)
+            self.app_service.switch_database(app_config.current_db_path, load_stats=False)
             self._update_db_label()
             self.statusBar().showMessage(
                 f"Подключена база данных: {os.path.basename(self.app_service.db_path)}"
             )
         except Exception as e:
-            logger.error(f"Ошибка при подключении к последней БД {config.LAST_DB_PATH}: {e}")
+            logger.error(f"Ошибка при подключении к последней БД {app_config.current_db_path}: {e}")
             self.statusBar().showMessage(f"Ошибка подключения к БД: {e}", 5000)
             self.manage_databases()
             return
@@ -167,7 +167,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         # Метка с именем подключенной базы данных и версией приложения в правой части тулбара
         self.toolbar.addWidget(self.db_status_label)
-        version_label = QtWidgets.QLabel(f"v{config.APP_VERSION}")
+        version_label = QtWidgets.QLabel(f"v{app_config.app_version}")
         version_label.setStyleSheet("color: #777; font-size: 9px; margin-right: 4px;")
         self.toolbar.addWidget(version_label)
 
@@ -218,7 +218,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 if hasattr(self, 'session_view') and self.session_view:
                     self.session_view.hide_loading_overlay()
 
-                config.set_db_path(new_path)
+                app_config.set_current_db_path(new_path)
                 # Сбрасываем кеши и запускаем асинхронную загрузку данных
                 self.invalidate_all_caches()
                 self.refresh_all_data()

--- a/ui/stats_grid.py
+++ b/ui/stats_grid.py
@@ -21,7 +21,7 @@ import math
 from statistics import median
 from datetime import datetime
 
-import config
+from services.app_config import app_config
 from services import AppFacade
 from models import OverallStats
 
@@ -60,7 +60,7 @@ from stats import (
 from ui.background import thread_manager
 
 logger = logging.getLogger('ROYAL_Stats.StatsGrid')
-logger.setLevel(logging.DEBUG if config.DEBUG else logging.INFO)
+logger.setLevel(logging.DEBUG if app_config.debug else logging.INFO)
 
 
 class StatCard(QtWidgets.QFrame):
@@ -1074,7 +1074,7 @@ class StatsGrid(QtWidgets.QWidget):
                 early_ko_count += h.hero_ko_this_hand
             pre_ft_ko_count += h.pre_ft_ko
             
-            if h.table_size == config.FINAL_TABLE_SIZE:
+            if h.table_size == app_config.final_table_size:
                 saved = first_hands.get(h.tournament_id)
                 if saved is None or h.hand_number < saved.hand_number:
                     first_hands[h.tournament_id] = h
@@ -1083,7 +1083,7 @@ class StatsGrid(QtWidgets.QWidget):
         stats.early_ft_ko_per_tournament = early_ko_count / ft_count if ft_count else 0.0
         stats.pre_ft_ko_count = round(pre_ft_ko_count, 1)
         stats.incomplete_ft_count = sum(
-            1 for h in first_hands.values() if h.players_count < config.FINAL_TABLE_SIZE
+            1 for h in first_hands.values() if h.players_count < app_config.final_table_size
         )
         all_places = [t.finish_place for t in tournaments if t.finish_place is not None]
         stats.avg_finish_place = sum(all_places) / len(all_places) if all_places else 0.0

--- a/ui/stats_grid.py.backup
+++ b/ui/stats_grid.py.backup
@@ -21,7 +21,7 @@ import math
 from statistics import median
 from datetime import datetime
 
-import config
+from services.app_config import app_config
 from application_service import ApplicationService
 from models import OverallStats
 
@@ -60,7 +60,7 @@ from stats import (
 from ui.background import thread_manager
 
 logger = logging.getLogger('ROYAL_Stats.StatsGrid')
-logger.setLevel(logging.DEBUG if config.DEBUG else logging.INFO)
+logger.setLevel(logging.DEBUG if app_config.debug else logging.INFO)
 
 
 class StatCard(QtWidgets.QFrame):
@@ -1208,7 +1208,7 @@ class StatsGrid(QtWidgets.QWidget):
                 early_ko_count += h.hero_ko_this_hand
             pre_ft_ko_count += h.pre_ft_ko
             
-            if h.table_size == config.FINAL_TABLE_SIZE:
+            if h.table_size == app_config.final_table_size:
                 saved = first_hands.get(h.tournament_id)
                 if saved is None or h.hand_number < saved.hand_number:
                     first_hands[h.tournament_id] = h
@@ -1217,7 +1217,7 @@ class StatsGrid(QtWidgets.QWidget):
         stats.early_ft_ko_per_tournament = early_ko_count / ft_count if ft_count else 0.0
         stats.pre_ft_ko_count = round(pre_ft_ko_count, 1)
         stats.incomplete_ft_count = sum(
-            1 for h in first_hands.values() if h.players_count < config.FINAL_TABLE_SIZE
+            1 for h in first_hands.values() if h.players_count < app_config.final_table_size
         )
         all_places = [t.finish_place for t in tournaments if t.finish_place is not None]
         stats.avg_finish_place = sum(all_places) / len(all_places) if all_places else 0.0


### PR DESCRIPTION
## Summary
- store poker parameters in new `config.ini`
- load ini in `AppConfig` and expose global `app_config`
- replace legacy `config` usage across services, parsers and UI
- export `app_config` from services package

## Testing
- `python -m py_compile services/app_config.py db/manager.py db/repositories/final_table_hand_repo.py parsers/base_parser.py parsers/tournament_summary.py parsers/hand_history.py ui/main_window.py ui/database_management_dialog.py ui/stats_grid.py ui/stats_grid.py.backup stats/incomplete_ft_percent.py stats/ko_contribution.py stats/early_ft_bust.py stats/ft_stack_conversion.py stats/ft_stack_conversion_attempts.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_6846a653def083239aaeff1a35ce7ab1