### PR TITLE
Implement parser plugin architecture

### DIFF
--- a/app.py
+++ b/app.py
@@ -31,7 +31,6 @@ from db.repositories import (
     PlaceDistributionRepository,
     FinalTableHandRepository,
 )
-from parsers import HandHistoryParser, TournamentSummaryParser
 
 
 # Настройка базового логгирования
@@ -76,10 +75,6 @@ class DependencyContainer:
         self.place_dist_repo = PlaceDistributionRepository(self.db_manager)
         self.ft_hand_repo = FinalTableHandRepository(self.db_manager)
 
-        # Создаем парсеры
-        self.hh_parser = HandHistoryParser(self.config.hero_name)
-        self.ts_parser = TournamentSummaryParser(self.config.hero_name)
-
         # Создаем сервисы
         self.import_service = self._create_import_service()
         self.statistics_service = self._create_statistics_service()
@@ -104,8 +99,7 @@ class DependencyContainer:
             tournament_repo=self.tournament_repo,
             session_repo=self.session_repo,
             ft_hand_repo=self.ft_hand_repo,
-            hh_parser=self.hh_parser,
-            ts_parser=self.ts_parser,
+            parser_plugins=None,
             event_bus=self.event_bus,
         )
 

--- a/parsers/__init__.py
+++ b/parsers/__init__.py
@@ -7,11 +7,24 @@
 from .hand_history import HandHistoryParser
 from .tournament_summary import TournamentSummaryParser
 from .base_parser import BaseParser
+from .base_plugin import BaseParserPlugin
 from .file_classifier import FileClassifier
+from plugins import discover_plugins as _discover_external_plugins
+
+def discover_plugins(entry_point_group: str = "royal_stats"):
+    """Возвращает все доступные классы плагинов-парсеров."""
+    plugins = [HandHistoryParser, TournamentSummaryParser]
+    discovered = _discover_external_plugins(entry_point_group)
+    for plugin_cls in discovered.get("parsers", []):
+        if issubclass(plugin_cls, BaseParserPlugin):
+            plugins.append(plugin_cls)
+    return plugins
 
 __all__ = [
     'HandHistoryParser',
     'TournamentSummaryParser',
     'BaseParser',
+    'BaseParserPlugin',
     'FileClassifier',
+    'discover_plugins',
 ]

--- a/parsers/base_plugin.py
+++ b/parsers/base_plugin.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+"""Базовый класс плагина-парсера для Royal Stats."""
+
+from typing import TypeVar, Generic
+
+from .base_parser import BaseParser
+from plugins.plugin_manager import Plugin
+
+T = TypeVar('T')
+
+
+class BaseParserPlugin(Plugin, BaseParser[T], Generic[T]):
+    """Базовый класс плагинов-парсеров."""
+
+    # Категория для plugin_manager
+    category: str = "parsers"
+    # Тип файла, который может обрабатывать парсер
+    file_type: str = ""
+
+    def can_handle(self, file_type: str) -> bool:
+        """Возвращает True, если парсер может обработать файл указанного типа."""
+        return file_type == self.file_type
+

--- a/parsers/hand_history.py
+++ b/parsers/hand_history.py
@@ -15,7 +15,7 @@ import logging
 from typing import Dict, List, Set, Tuple, Optional, Any
 from services.app_config import app_config
 from models import Tournament, FinalTableHand # Импортируем модели
-from .base_parser import BaseParser # ИМПОРТИРУЕМ BaseParser
+from .base_plugin import BaseParserPlugin  # Базовый класс плагина-парсера
 from .parse_results import HandHistoryResult
 
 logger = logging.getLogger('ROYAL_Stats.HandHistoryParser')
@@ -77,7 +77,11 @@ class HandData:
         self.players = list(seats.keys())  # Список игроков за столом в этой раздаче
         self.eliminated_players = set()  # Игроки, выбывшие в этой раздаче
 
-class HandHistoryParser(BaseParser[HandHistoryResult]):
+class HandHistoryParser(BaseParserPlugin[HandHistoryResult]):
+    """Плагин-парсер hand history."""
+
+    name = "hand_history_parser"
+    file_type = "hh"
     def __init__(self, hero_name: str = app_config.hero_name):
         super().__init__(hero_name)
         self._tournament_id: Optional[str] = None

--- a/parsers/tournament_summary.py
+++ b/parsers/tournament_summary.py
@@ -11,17 +11,18 @@ import re
 import logging
 from typing import Dict, Any, Optional
 from services.app_config import app_config
-from .base_parser import BaseParser # Наследуем от BaseParser
+from .base_plugin import BaseParserPlugin  # Базовый класс плагина-парсера
 from .parse_results import TournamentSummaryResult
 
 logger = logging.getLogger('ROYAL_Stats.TournamentSummaryParser')
 logger.setLevel(logging.DEBUG if app_config.debug else logging.INFO)
 
 
-class TournamentSummaryParser(BaseParser[TournamentSummaryResult]):
-    """
-    Парсер summary-файла турнира только для Hero.
-    """
+class TournamentSummaryParser(BaseParserPlugin[TournamentSummaryResult]):
+    """Плагин-парсер summary-файла турнира только для Hero."""
+
+    name = "tournament_summary_parser"
+    file_type = "ts"
 
     def __init__(self, hero_name: str = app_config.hero_name):
         super().__init__(hero_name)
@@ -149,3 +150,4 @@ class TournamentSummaryParser(BaseParser[TournamentSummaryResult]):
             payout=payout,
             finish_place=finish_place
         )
+

--- a/services/app_facade.py
+++ b/services/app_facade.py
@@ -20,7 +20,6 @@ from db.repositories import (
     PlaceDistributionRepository,
     FinalTableHandRepository,
 )
-from parsers import HandHistoryParser, TournamentSummaryParser
 
 from .import_service import ImportService
 from .statistics_service import StatisticsService


### PR DESCRIPTION
## Summary
- introduce `BaseParserPlugin` for plugin-based parsers
- migrate `HandHistoryParser` and `TournamentSummaryParser` to new base
- discover parser plugins in `ImportService`
- update dependency container to use automatic parser discovery
- minor cleanup of unused imports

## Testing
- `python -m py_compile services/import_service.py parsers/__init__.py parsers/base_plugin.py parsers/hand_history.py parsers/tournament_summary.py app.py`
- `python -m unittest discover -v tests` *(fails: ModuleNotFoundError and other test errors)*

------
https://chatgpt.com/codex/tasks/task_e_6846e15075e88323b03a25b8d050c115