### PR TITLE
Refactor: Reduce verbosity of INFO logs during import

### DIFF
--- a/services/import_service.py
+++ b/services/import_service.py
@@ -319,7 +319,7 @@ class ImportService:
         else:
             try:
                 current_session = self.session_repo.create_session(session_name or "")
-                logger.info(f"Создана новая сессия для импорта: {current_session.session_id}")
+                logger.debug(f"Создана новая сессия для импорта: {current_session.session_id}")
             except Exception as e:
                 logger.error(f"Не удалось создать сессию для импорта: {e}")
                 return None
@@ -548,7 +548,7 @@ class ImportService:
         saved_tournaments.extend(tournament_objects)
         updated_tournament_ids.extend(updated_ids)
         
-        logger.info(f"Сохранено/обновлено {tournaments_saved} турниров.")
+        logger.debug(f"Сохранено/обновлено {tournaments_saved} турниров.")
         
         # Сохраняем руки финального стола
         hands_saved, hand_objects = self._save_final_table_hands(


### PR DESCRIPTION
I've changed specific INFO-level log messages in `services/import_service.py` to DEBUG level. This addresses the issue of excessive logging in the INFO category, particularly during file import operations.

The following changes were made:
- The log message for new session creation (`Создана новая сессия для импорта`) was changed from INFO to DEBUG as it's more relevant for debugging than for a general overview of the import process.
- The log message for the number of tournaments saved/updated (`Сохранено/обновлено турниров`) was changed from INFO to DEBUG as it's a sub-step and somewhat redundant given a subsequent summary log.

Essential INFO logs that describe key application work stages (e.g., start/end of import, overall save summaries) and application lifecycle events in `app.py` have been retained. This change ensures that the INFO log level provides a clearer, high-level view of the application's operations while detailed logs remain available at the DEBUG level.