### PR TITLE
Add bulk insert methods

### DIFF
--- a/db/repositories/tournament_repo.py
+++ b/db/repositories/tournament_repo.py
@@ -88,6 +88,61 @@ class TournamentRepository:
 
         self.db.execute_update(query, params)
 
+    def add_or_update_many(self, tournaments: List[Tournament]):
+        """Пакетное добавление или обновление турниров."""
+        if not tournaments:
+            return 0
+
+        query = """
+            INSERT INTO tournaments (
+                tournament_id, tournament_name, start_time, buyin, payout,
+                finish_place, ko_count, session_id, reached_final_table,
+                final_table_initial_stack_chips, final_table_initial_stack_bb,
+                final_table_start_players
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(tournament_id)
+            DO UPDATE SET
+                tournament_name = COALESCE(excluded.tournament_name, tournaments.tournament_name),
+                start_time = COALESCE(excluded.start_time, tournaments.start_time),
+                buyin = COALESCE(excluded.buyin, tournaments.buyin),
+                payout = COALESCE(excluded.payout, tournaments.payout),
+                finish_place = COALESCE(excluded.finish_place, tournaments.finish_place),
+                ko_count = excluded.ko_count,
+                session_id = COALESCE(tournaments.session_id, excluded.session_id),
+                reached_final_table = tournaments.reached_final_table OR excluded.reached_final_table,
+                final_table_initial_stack_chips = COALESCE(excluded.final_table_initial_stack_chips, tournaments.final_table_initial_stack_chips),
+                final_table_initial_stack_bb = COALESCE(excluded.final_table_initial_stack_bb, tournaments.final_table_initial_stack_bb),
+                final_table_start_players = COALESCE(excluded.final_table_start_players, tournaments.final_table_start_players)
+        """
+
+        params_list = [
+            (
+                t.tournament_id,
+                t.tournament_name,
+                t.start_time,
+                t.buyin,
+                t.payout,
+                t.finish_place,
+                t.ko_count,
+                t.session_id,
+                t.reached_final_table,
+                t.final_table_initial_stack_chips,
+                t.final_table_initial_stack_bb,
+                t.final_table_start_players,
+            )
+            for t in tournaments
+        ]
+
+        try:
+            conn = self.db.get_connection()
+            cursor = conn.cursor()
+            cursor.executemany(query, params_list)
+            conn.commit()
+            return cursor.rowcount
+        except Exception as e:
+            print(f"Ошибка пакетного сохранения турниров: {e}")
+            raise
+
 
     def get_tournament_by_id(self, tournament_id: str) -> Optional[Tournament]:
         """


### PR DESCRIPTION
## Summary
- add `add_hands` to final_table_hand_repo for executemany inserts
- add `add_or_update_many` to tournament_repo
- use new batch methods in `ImportService`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'config')*

------
https://chatgpt.com/codex/tasks/task_e_684712104154832387458bb2963ad291