### PR TITLE
Fix KO stage stats counting issue

### DIFF
--- a/stats/ko_stage_2_3.py
+++ b/stats/ko_stage_2_3.py
@@ -41,16 +41,11 @@ class KOStage23Stat(BaseStat):
             if hand.players_count >= 2 and hand.players_count <= 3
         ]
         
-        # Подсчитываем KO
-        ko_count = 0
-        ko_amount = 0.0
-        
-        for hand in stage_2_3_hands:
-            if hand.hero_ko_this_hand > 0:
-                ko_count += 1
-                ko_amount += hand.hero_ko_this_hand
-        
+        # Подсчитываем KO. В hero_ko_this_hand может быть дробное
+        # значение, если награда разделена между несколькими игроками.
+        ko_total = sum(hand.hero_ko_this_hand for hand in stage_2_3_hands)
+
         return {
-            "ko_stage_2_3": ko_count,
-            "ko_stage_2_3_amount": round(ko_amount, 2)
+            "ko_stage_2_3": round(ko_total, 2),
+            "ko_stage_2_3_amount": round(ko_total, 2)
         }

--- a/stats/ko_stage_4_5.py
+++ b/stats/ko_stage_4_5.py
@@ -42,15 +42,9 @@ class KOStage45Stat(BaseStat):
         ]
         
         # Подсчитываем KO
-        ko_count = 0
-        ko_amount = 0.0
-        
-        for hand in stage_4_5_hands:
-            if hand.hero_ko_this_hand > 0:
-                ko_count += 1
-                ko_amount += hand.hero_ko_this_hand
-        
+        ko_total = sum(hand.hero_ko_this_hand for hand in stage_4_5_hands)
+
         return {
-            "ko_stage_4_5": ko_count,
-            "ko_stage_4_5_amount": round(ko_amount, 2)
+            "ko_stage_4_5": round(ko_total, 2),
+            "ko_stage_4_5_amount": round(ko_total, 2)
         }

--- a/stats/ko_stage_6_9.py
+++ b/stats/ko_stage_6_9.py
@@ -42,15 +42,9 @@ class KOStage69Stat(BaseStat):
         ]
         
         # Подсчитываем KO
-        ko_count = 0
-        ko_amount = 0.0
-        
-        for hand in stage_6_9_hands:
-            if hand.hero_ko_this_hand > 0:
-                ko_count += 1
-                ko_amount += hand.hero_ko_this_hand
-        
+        ko_total = sum(hand.hero_ko_this_hand for hand in stage_6_9_hands)
+
         return {
-            "ko_stage_6_9": ko_count,
-            "ko_stage_6_9_amount": round(ko_amount, 2)
+            "ko_stage_6_9": round(ko_total, 2),
+            "ko_stage_6_9_amount": round(ko_total, 2)
         }


### PR DESCRIPTION
## Summary
- correct KO counting for different final table stages

## Testing
- `No tests run due to user request`

------
https://chatgpt.com/codex/tasks/task_e_684a4ad465cc83238001a5c5fd3b5c38