### PR TITLE
Исправление выводов выигрышных статов

### DIFF
--- a/stats/winnings_from_itm_stat.py
+++ b/stats/winnings_from_itm_stat.py
@@ -35,8 +35,9 @@ class WinningsFromITMStat(BaseStat):
             **kwargs: Дополнительные параметры
 
         Returns:
-            Словарь с ключом:
-            - 'value': общая сумма выигрыша от ITM
+            Словарь с ключами:
+            - 'winnings_from_itm': общая сумма выигрыша от ITM
+            - 'value': то же значение для обратной совместимости
         """
         tournaments = tournaments or []
         total_itm_winnings = 0.0
@@ -54,6 +55,8 @@ class WinningsFromITMStat(BaseStat):
 
         total_itm_winnings = round(total_itm_winnings, 2)
 
+        # Возвращаем значение под ожидаемым ключом, сохраняя "value" для совместимости
         return {
+            "winnings_from_itm": total_itm_winnings,
             "value": total_itm_winnings
         }

--- a/stats/winnings_from_ko_stat.py
+++ b/stats/winnings_from_ko_stat.py
@@ -31,9 +31,10 @@ class WinningsFromKOStat(BaseStat):
             **kwargs: Дополнительные параметры, включая precomputed_stats
 
         Returns:
-            Словарь с ключом:
-            - 'value': общая сумма выигрыша от KO
-            - 'total_ko_amount': также общая сумма выигрыша от KO для возможной совместимости
+            Словарь с ключами:
+            - 'winnings_from_ko': общая сумма выигрыша от KO
+            - 'value': то же значение для обратной совместимости
+            - 'total_ko_amount': общая сумма выигрыша от KO
         """
         precomputed_stats = kwargs.get('precomputed_stats', {})
 
@@ -66,7 +67,10 @@ class WinningsFromKOStat(BaseStat):
 
         total_ko_amount = round(total_ko_amount, 2)
 
+        # Возвращаем сумму под ключом, который ожидает ViewModel.
+        # Также оставляем старый ключ "value" для возможной совместимости
         return {
+            "winnings_from_ko": total_ko_amount,
             "value": total_ko_amount,
-            "total_ko_amount": total_ko_amount # для обратной совместимости или других нужд
+            "total_ko_amount": total_ko_amount
         }


### PR DESCRIPTION
## Summary
- скорректированы плагины `winnings_from_ko_stat` и `winnings_from_itm_stat`
- теперь они возвращают значения под ключами `winnings_from_ko` и `winnings_from_itm`
- оставлены старые ключи `value` для совместимости

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a50744a8c83239cad12826d30083b