### PR TITLE
Fix preFT stat in toolbar

### DIFF
--- a/services/app_facade.py
+++ b/services/app_facade.py
@@ -561,6 +561,20 @@ class AppFacade:
         
         # Pre-FT KO
         stats.pre_ft_ko_count = sum(hand.pre_ft_ko for hand in ft_hands)
+
+        # Средний результат до финального стола (ChipEV)
+        ft_stack_sum = sum(
+            t.final_table_initial_stack_chips for t in tournaments
+            if t.final_table_initial_stack_chips is not None
+        )
+        not_ft_count = stats.total_tournaments - stats.total_final_tables
+        if stats.total_tournaments > 0:
+            stats.pre_ft_chipev = (
+                ft_stack_sum - not_ft_count * 1000
+            ) / stats.total_tournaments
+        else:
+            stats.pre_ft_chipev = 0.0
+        stats.pre_ft_chipev = round(stats.pre_ft_chipev, 2)
         
         return stats
 


### PR DESCRIPTION
## Summary
- fix calculation of preFT ChipEV in `AppFacade._compute_overall_stats_filtered`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'config')*

------
https://chatgpt.com/codex/tasks/task_e_684a70558c108323af9603b92956c150