### PR TITLE
Add tournament data presence flags

### DIFF
--- a/db/repositories/session_repo.py
+++ b/db/repositories/session_repo.py
@@ -145,7 +145,7 @@ class SessionRepository:
                 SUM(CASE WHEN payout IS NOT NULL THEN payout ELSE 0 END) as total_prize,
                 SUM(CASE WHEN buyin IS NOT NULL THEN buyin ELSE 0 END) as total_buy_in
             FROM tournaments
-            WHERE session_id = ?
+            WHERE session_id = ? AND has_ts = 1
         """
         
         # Получаем количество KO

--- a/db/repositories/tournament_repo.py
+++ b/db/repositories/tournament_repo.py
@@ -52,10 +52,10 @@ class TournamentRepository:
         query = """
             INSERT INTO tournaments (
                 tournament_id, tournament_name, start_time, buyin, payout,
-                finish_place, ko_count, session_id, reached_final_table,
-                final_table_initial_stack_chips, final_table_initial_stack_bb,
-                final_table_start_players
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                finish_place, ko_count, session_id, has_ts, has_hh,
+                reached_final_table, final_table_initial_stack_chips,
+                final_table_initial_stack_bb, final_table_start_players
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(tournament_id)
             DO UPDATE SET
                 tournament_name = COALESCE(excluded.tournament_name, tournaments.tournament_name),
@@ -65,6 +65,8 @@ class TournamentRepository:
                 finish_place = COALESCE(excluded.finish_place, tournaments.finish_place),
                 ko_count = excluded.ko_count, -- ko_count приходит уже объединенный из ImportService
                 session_id = COALESCE(tournaments.session_id, excluded.session_id), -- Сохраняем первый session_id, если новый не установлен
+                has_ts = tournaments.has_ts OR excluded.has_ts,
+                has_hh = tournaments.has_hh OR excluded.has_hh,
                 reached_final_table = tournaments.reached_final_table OR excluded.reached_final_table, -- Флаг становится TRUE если хоть раз был TRUE
                 final_table_initial_stack_chips = COALESCE(excluded.final_table_initial_stack_chips, tournaments.final_table_initial_stack_chips),
                 final_table_initial_stack_bb = COALESCE(excluded.final_table_initial_stack_bb, tournaments.final_table_initial_stack_bb),
@@ -80,6 +82,8 @@ class TournamentRepository:
             tournament.finish_place,
             tournament.ko_count,
             tournament.session_id,
+            int(tournament.has_ts),
+            int(tournament.has_hh),
             tournament.reached_final_table,
             tournament.final_table_initial_stack_chips,
             tournament.final_table_initial_stack_bb,
@@ -96,10 +100,10 @@ class TournamentRepository:
         query = """
             INSERT INTO tournaments (
                 tournament_id, tournament_name, start_time, buyin, payout,
-                finish_place, ko_count, session_id, reached_final_table,
-                final_table_initial_stack_chips, final_table_initial_stack_bb,
-                final_table_start_players
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                finish_place, ko_count, session_id, has_ts, has_hh,
+                reached_final_table, final_table_initial_stack_chips,
+                final_table_initial_stack_bb, final_table_start_players
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(tournament_id)
             DO UPDATE SET
                 tournament_name = COALESCE(excluded.tournament_name, tournaments.tournament_name),
@@ -109,6 +113,8 @@ class TournamentRepository:
                 finish_place = COALESCE(excluded.finish_place, tournaments.finish_place),
                 ko_count = excluded.ko_count,
                 session_id = COALESCE(tournaments.session_id, excluded.session_id),
+                has_ts = tournaments.has_ts OR excluded.has_ts,
+                has_hh = tournaments.has_hh OR excluded.has_hh,
                 reached_final_table = tournaments.reached_final_table OR excluded.reached_final_table,
                 final_table_initial_stack_chips = COALESCE(excluded.final_table_initial_stack_chips, tournaments.final_table_initial_stack_chips),
                 final_table_initial_stack_bb = COALESCE(excluded.final_table_initial_stack_bb, tournaments.final_table_initial_stack_bb),
@@ -125,6 +131,8 @@ class TournamentRepository:
                 t.finish_place,
                 t.ko_count,
                 t.session_id,
+                int(t.has_ts),
+                int(t.has_hh),
                 t.reached_final_table,
                 t.final_table_initial_stack_chips,
                 t.final_table_initial_stack_bb,
@@ -151,9 +159,9 @@ class TournamentRepository:
         query = """
             SELECT
                 id, tournament_id, tournament_name, start_time, buyin, payout,
-                finish_place, ko_count, session_id, reached_final_table,
-                final_table_initial_stack_chips, final_table_initial_stack_bb,
-                final_table_start_players
+                finish_place, ko_count, session_id, has_ts, has_hh,
+                reached_final_table, final_table_initial_stack_chips,
+                final_table_initial_stack_bb, final_table_start_players
             FROM tournaments
             WHERE tournament_id=?
         """
@@ -177,9 +185,9 @@ class TournamentRepository:
         query = """
             SELECT
                 id, tournament_id, tournament_name, start_time, buyin, payout,
-                finish_place, ko_count, session_id, reached_final_table,
-                final_table_initial_stack_chips, final_table_initial_stack_bb,
-                final_table_start_players
+                finish_place, ko_count, session_id, has_ts, has_hh,
+                reached_final_table, final_table_initial_stack_chips,
+                final_table_initial_stack_bb, final_table_start_players
             FROM tournaments
         """
         conditions = []
@@ -542,9 +550,9 @@ class TournamentRepository:
         base_query = """
             SELECT
                 id, tournament_id, tournament_name, start_time, buyin, payout,
-                finish_place, ko_count, session_id, reached_final_table,
-                final_table_initial_stack_chips, final_table_initial_stack_bb,
-                final_table_start_players
+                finish_place, ko_count, session_id, has_ts, has_hh,
+                reached_final_table, final_table_initial_stack_chips,
+                final_table_initial_stack_bb, final_table_start_players
             FROM tournaments
         """
         count_query = "SELECT COUNT(*) FROM tournaments"

--- a/db/schema.py
+++ b/db/schema.py
@@ -33,6 +33,8 @@ CREATE TABLE IF NOT EXISTS tournaments (
     finish_place INTEGER,
     ko_count REAL DEFAULT 0,
     session_id TEXT,
+    has_ts BOOLEAN DEFAULT 0,
+    has_hh BOOLEAN DEFAULT 0,
     reached_final_table BOOLEAN DEFAULT 0,
     final_table_initial_stack_chips REAL,
     final_table_initial_stack_bb REAL,

--- a/models/tournament.py
+++ b/models/tournament.py
@@ -24,6 +24,8 @@ class Tournament(BaseModel):
     finish_place: Optional[int] = None # None, если не закончил турнир в этой сессии
     ko_count: float = 0.0 # Общее количество KO Hero в турнире
     session_id: Optional[str] = None # ID сессии импорта
+    has_ts: bool = False
+    has_hh: bool = False
     reached_final_table: bool = False # Достиг ли Hero финального стола 9-max
     final_table_initial_stack_chips: Optional[float] = None # Стек на старте финалки в фишках
     final_table_initial_stack_bb: Optional[float] = None # Стек на старте финалки в BB

--- a/services/import_service.py
+++ b/services/import_service.py
@@ -438,17 +438,21 @@ class ImportService:
             # Инициализируем запись в словаре, если ее нет
             if tourney_id not in parsed_tournaments_data:
                 parsed_tournaments_data[tourney_id] = {
-                    'tournament_id': tourney_id, 
-                    'session_id': session_id, 
-                    'ko_count': 0, 
-                    'reached_final_table': False
+                    'tournament_id': tourney_id,
+                    'session_id': session_id,
+                    'ko_count': 0,
+                    'reached_final_table': False,
+                    'has_ts': False,
+                    'has_hh': False
                 }
             
             # Добавляем данные из HH к временной записи турнира
             parsed_tournaments_data[tourney_id]['start_time'] = (
-                parsed_tournaments_data[tourney_id].get('start_time') or 
+                parsed_tournaments_data[tourney_id].get('start_time') or
                 hh_result.start_time
             )
+
+            parsed_tournaments_data[tourney_id]['has_hh'] = True
             
             # Обновляем временные данные турнира из HH
             if hh_result.reached_final_table:
@@ -499,10 +503,12 @@ class ImportService:
             # Инициализируем запись, если ее нет
             if tourney_id not in parsed_tournaments_data:
                 parsed_tournaments_data[tourney_id] = {
-                    'tournament_id': tourney_id, 
-                    'session_id': session_id, 
-                    'ko_count': 0, 
-                    'reached_final_table': False
+                    'tournament_id': tourney_id,
+                    'session_id': session_id,
+                    'ko_count': 0,
+                    'reached_final_table': False,
+                    'has_ts': False,
+                    'has_hh': False
                 }
             
             # Обновляем временные данные турнира из TS (TS имеет приоритет)
@@ -511,9 +517,11 @@ class ImportService:
                 parsed_tournaments_data[tourney_id].get('tournament_name')
             )
             parsed_tournaments_data[tourney_id]['start_time'] = (
-                ts_result.start_time or 
+                ts_result.start_time or
                 parsed_tournaments_data[tourney_id].get('start_time')
             )
+
+            parsed_tournaments_data[tourney_id]['has_ts'] = True
             parsed_tournaments_data[tourney_id]['buyin'] = (
                 ts_result.buyin or 
                 parsed_tournaments_data[tourney_id].get('buyin')
@@ -649,6 +657,17 @@ class ImportService:
                     final_tourney_data.update(existing_tourney.as_dict())
 
                 final_tourney_data.update(data)
+
+                if existing_tourney:
+                    final_tourney_data['has_ts'] = (
+                        existing_tourney.has_ts or data.get('has_ts', False)
+                    )
+                    final_tourney_data['has_hh'] = (
+                        existing_tourney.has_hh or data.get('has_hh', False)
+                    )
+                else:
+                    final_tourney_data['has_ts'] = data.get('has_ts', False)
+                    final_tourney_data['has_hh'] = data.get('has_hh', False)
 
                 if existing_tourney and existing_tourney.reached_final_table:
                     final_tourney_data['reached_final_table'] = True

--- a/services/statistics_service.py
+++ b/services/statistics_service.py
@@ -431,23 +431,23 @@ class StatisticsService:
         )
         
         stats = OverallStats()
-        
-        stats.total_tournaments = len(all_tournaments)
-        
-        # Фильтруем турниры, достигшие финального стола
-        final_table_tournaments = [t for t in all_tournaments if t.reached_final_table]
+
+        tournaments_with_ts = [t for t in all_tournaments if t.has_ts]
+        tournaments_with_hh = [t for t in all_tournaments if t.has_hh]
+
+        stats.total_tournaments = len(tournaments_with_ts)
+
+        final_table_tournaments = [t for t in tournaments_with_hh if t.reached_final_table]
         stats.total_final_tables = len(final_table_tournaments)
-        
-        # Расчеты, основанные на турнирах:
-        stats.total_buy_in = sum(t.buyin for t in all_tournaments if t.buyin is not None)
-        stats.total_prize = sum(t.payout if t.payout is not None else 0 for t in all_tournaments)
-        
-        # Среднее место по всем турнирам (включая не финалку)
-        all_places = [t.finish_place for t in all_tournaments if t.finish_place is not None]
+
+        stats.total_buy_in = sum(t.buyin for t in tournaments_with_ts if t.buyin is not None)
+        stats.total_prize = sum(t.payout if t.payout is not None else 0 for t in tournaments_with_ts)
+
+        all_places = [t.finish_place for t in tournaments_with_ts if t.finish_place is not None]
         stats.avg_finish_place = sum(all_places) / len(all_places) if all_places else 0.0
-        
-        # Среднее место только на финалке (1-9)
-        ft_places = [t.finish_place for t in final_table_tournaments if t.finish_place is not None and 1 <= t.finish_place <= 9]
+
+        final_table_tournaments_with_ts = [t for t in final_table_tournaments if t.has_ts]
+        ft_places = [t.finish_place for t in final_table_tournaments_with_ts if t.finish_place is not None and 1 <= t.finish_place <= 9]
         stats.avg_finish_place_ft = sum(ft_places) / len(ft_places) if ft_places else 0.0
         
         # Общее количество KO
@@ -456,15 +456,23 @@ class StatisticsService:
         
         # Avg KO / Tournament
         stats.avg_ko_per_tournament = stats.total_knockouts / stats.total_tournaments if stats.total_tournaments > 0 else 0.0
-        
+
         # % Reach FT
         stats.final_table_reach_percent = (stats.total_final_tables / stats.total_tournaments * 100) if stats.total_tournaments > 0 else 0.0
-        
+
         # Средний стек на старте финалки (чипсы и BB)
-        ft_initial_stacks_chips = [t.final_table_initial_stack_chips for t in final_table_tournaments if t.final_table_initial_stack_chips is not None]
+        ft_initial_stacks_chips = [
+            t.final_table_initial_stack_chips
+            for t in final_table_tournaments
+            if t.final_table_initial_stack_chips is not None
+        ]
         stats.avg_ft_initial_stack_chips = sum(ft_initial_stacks_chips) / len(ft_initial_stacks_chips) if ft_initial_stacks_chips else 0.0
-        
-        ft_initial_stacks_bb = [t.final_table_initial_stack_bb for t in final_table_tournaments if t.final_table_initial_stack_bb is not None]
+
+        ft_initial_stacks_bb = [
+            t.final_table_initial_stack_bb
+            for t in final_table_tournaments
+            if t.final_table_initial_stack_bb is not None
+        ]
         stats.avg_ft_initial_stack_bb = sum(ft_initial_stacks_bb) / len(ft_initial_stacks_bb) if ft_initial_stacks_bb else 0.0
         
         # Расчеты для "ранней стадии финалки" (9-6 игроков)
@@ -477,7 +485,7 @@ class StatisticsService:
         # Вылеты Hero на ранней стадии финалки (6-9 место)
         stats.early_ft_bust_count = sum(
             1
-            for t in final_table_tournaments
+            for t in final_table_tournaments_with_ts
             if t.finish_place is not None and 6 <= t.finish_place <= 9
         )
         stats.early_ft_bust_per_tournament = (
@@ -504,8 +512,12 @@ class StatisticsService:
         # Pre-FT ChipEV будет рассчитан плагином
         
         # Логируем статистику по выплатам для отладки
-        tournaments_with_payout = sum(1 for t in all_tournaments if t.payout is not None and t.payout > 0)
-        tournaments_without_payout = sum(1 for t in all_tournaments if t.payout is None or t.payout == 0)
+        tournaments_with_payout = sum(
+            1 for t in tournaments_with_ts if t.payout is not None and t.payout > 0
+        )
+        tournaments_without_payout = sum(
+            1 for t in tournaments_with_ts if t.payout is None or t.payout == 0
+        )
         logger.debug(
             f"Турниры с выплатами: {tournaments_with_payout}, без выплат: {tournaments_without_payout}"
         )
@@ -560,8 +572,11 @@ class StatisticsService:
             logger.warning("Плагин Pre-FT ChipEV не найден в результатах!")
         
         # Среднее место когда НЕ дошел до финалки
-        no_ft_places = [t.finish_place for t in all_tournaments 
-                       if not t.reached_final_table and t.finish_place is not None]
+        no_ft_places = [
+            t.finish_place
+            for t in tournaments_with_ts
+            if not t.reached_final_table and t.finish_place is not None
+        ]
         stats.avg_finish_place_no_ft = sum(no_ft_places) / len(no_ft_places) if no_ft_places else 0.0
         stats.avg_finish_place_no_ft = round(stats.avg_finish_place_no_ft, 2)
         


### PR DESCRIPTION
## Summary
- add `has_ts` and `has_hh` flags to tournaments schema
- support new flags in `Tournament` dataclass
- populate flags during import
- persist flags in repositories
- respect flags while calculating statistics
- filter session stats by `has_ts`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'config')*

------
https://chatgpt.com/codex/tasks/task_e_684aa50430588323b2aa2e6df4cb8d60