### PR TITLE
Добавлены статы глубокой финалки

### DIFF
--- a/stats/deep_ft_stat.py
+++ b/stats/deep_ft_stat.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+"""
+Статистика глубокой стадии финального стола (5 игроков и меньше).
+Возвращает частоту достижения этой стадии, средний стек и ROI.
+"""
+from typing import Dict, Any, List, Optional
+
+from .base import BaseStat
+from models import Tournament, FinalTableHand, Session
+
+
+class DeepFTStat(BaseStat):
+    """Статистика по стадии \u22645 игроков на финальном столе."""
+
+    name = "Deep FT"
+    description = (
+        "Проходы в глубокую стадию финалки (\u22645 игроков), "
+        "средний стек и ROI в таких турнирах"
+    )
+
+    def compute(
+        self,
+        tournaments: Optional[List[Tournament]] = None,
+        final_table_hands: Optional[List[FinalTableHand]] = None,
+        sessions: Optional[List[Session]] = None,
+        overall_stats: Optional[Any] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        tournaments = tournaments or []
+        final_table_hands = final_table_hands or []
+
+        # Сохраняем первую руку, где игроков 5 или меньше
+        first_hands: dict[str, FinalTableHand] = {}
+        for hand in final_table_hands:
+            if hand.players_count <= 5:
+                saved = first_hands.get(hand.tournament_id)
+                if saved is None or hand.hand_number < saved.hand_number:
+                    first_hands[hand.tournament_id] = hand
+
+        reached_ids = set(first_hands.keys())
+
+        if overall_stats and hasattr(overall_stats, "total_final_tables"):
+            total_ft = overall_stats.total_final_tables
+        else:
+            total_ft = sum(1 for t in tournaments if t.reached_final_table)
+
+        reach_percent = (len(reached_ids) / total_ft * 100) if total_ft else 0.0
+
+        stacks_chips = [h.hero_stack for h in first_hands.values() if h.hero_stack is not None]
+        avg_stack_chips = sum(stacks_chips) / len(stacks_chips) if stacks_chips else 0.0
+
+        stacks_bb = [h.hero_stack / h.bb for h in first_hands.values() if h.hero_stack is not None and h.bb]
+        avg_stack_bb = sum(stacks_bb) / len(stacks_bb) if stacks_bb else 0.0
+
+        stage_tournaments = [t for t in tournaments if t.tournament_id in reached_ids]
+        total_buyin = sum(t.buyin for t in stage_tournaments if t.buyin is not None)
+        total_payout = sum(t.payout for t in stage_tournaments if t.payout is not None)
+        roi = (total_payout - total_buyin) / total_buyin * 100 if total_buyin > 0 else 0.0
+
+        return {
+            "deep_ft_reach_percent": round(reach_percent, 2),
+            "deep_ft_avg_stack_chips": round(avg_stack_chips, 2),
+            "deep_ft_avg_stack_bb": round(avg_stack_bb, 2),
+            "deep_ft_roi": round(roi, 2),
+        }

--- a/ui/stats_grid.py
+++ b/ui/stats_grid.py
@@ -373,6 +373,9 @@ class StatsGrid(QtWidgets.QWidget):
             'ko_stage_2_3': SpecialStatCard("KO 2-3 игрока", "-"),
             'ko_stage_4_5': SpecialStatCard("KO 4-5 игроков", "-"),
             'ko_stage_6_9': StatCard("KO 6-9 игроков", "-"),
+            'deep_ft_reach': StatCard("% Проход <=5", "-"),
+            'deep_ft_stack': SpecialStatCard("Стек при <=5", "-"),
+            'deep_ft_roi': StatCard("ROI <=5", "-"),
         }
         
         # Словарь с описаниями для тултипов
@@ -397,6 +400,9 @@ class StatsGrid(QtWidgets.QWidget):
             'ko_stage_2_3': "Количество нокаутов в стадии 2-3 человека (хедз-ап и 3-макс).\nВо второй строке \u2014 среднее число попыток нокаута на турнир с FT",
             'ko_stage_4_5': "Количество нокаутов в стадии 4-5 человек.\nВо второй строке \u2014 среднее число попыток нокаута на турнир с FT",
             'ko_stage_6_9': "Количество нокаутов в стадии 6-9 человек (ранняя стадия финального стола)",
+            'deep_ft_reach': "Доля финальных столов, где Hero дошел до 5 и менее игроков",
+            'deep_ft_stack': "Средний стек Hero при 5 и менее игроках на финальном столе",
+            'deep_ft_roi': "ROI в турнирах с достижением стадии 5 игроков и меньше",
         }
         
         # Устанавливаем тултипы для карточек
@@ -410,6 +416,7 @@ class StatsGrid(QtWidgets.QWidget):
             ('ft_reach', 1, 0), ('avg_ft_stack', 1, 1), ('early_ft_ko', 1, 2), ('ft_stack_conv', 1, 3), ('pre_ft_ko', 1, 4),
             ('avg_place_all', 2, 0), ('avg_place_ft', 2, 1), ('avg_place_no_ft', 2, 2), ('early_ft_bust', 2, 3), ('ko_contribution', 2, 4),
             ('winnings_from_ko', 3, 0), ('winnings_from_itm', 3, 1), ('ko_stage_2_3', 3, 2), ('ko_stage_4_5', 3, 3), ('ko_stage_6_9', 3, 4),
+            ('deep_ft_reach', 4, 0), ('deep_ft_stack', 4, 1), ('deep_ft_roi', 4, 2),
         ]
         
         for key, row, col in positions:

--- a/viewmodels/stats_grid.py
+++ b/viewmodels/stats_grid.py
@@ -18,7 +18,7 @@ from stats import (
     FTStackConversionStat, FTStackConversionAttemptsStat,
     PreFTKOStat, KOLuckStat, ROIAdjustedStat, KOContributionStat,
     KOStage23Stat, KOStage45Stat, KOStage69Stat,
-    WinningsFromITMStat, WinningsFromKOStat
+    WinningsFromITMStat, WinningsFromKOStat, DeepFTStat
 )
 
 
@@ -181,9 +181,15 @@ class StatsGridViewModel:
         
         ko_stage_6_9_res = KOStage69Stat().compute(tournaments, final_table_hands)
         ko_stage_6_9 = ko_stage_6_9_res.get('ko_stage_6_9', 0)
-        
+
         winnings_from_itm_res = WinningsFromITMStat().compute(tournaments, final_table_hands, precomputed_stats=precomputed_stats)
         winnings_from_itm = winnings_from_itm_res.get('winnings_from_itm', 0.0)
+
+        deep_ft_res = DeepFTStat().compute(tournaments, final_table_hands, overall_stats=overall_stats)
+        deep_ft_reach = deep_ft_res.get('deep_ft_reach_percent', 0.0)
+        deep_ft_stack_chips = deep_ft_res.get('deep_ft_avg_stack_chips', 0.0)
+        deep_ft_stack_bb = deep_ft_res.get('deep_ft_avg_stack_bb', 0.0)
+        deep_ft_roi = deep_ft_res.get('deep_ft_roi', 0.0)
         
         # Расчет средних мест
         all_places = [t.finish_place for t in tournaments if t.finish_place is not None]
@@ -277,6 +283,23 @@ class StatsGridViewModel:
                 title="Выигрыш от ITM",
                 value=f"${winnings_from_itm:.0f}",
                 tooltip="Сумма, полученная от попадания в призы (места 1-3)"
+            ),
+            'deep_ft_reach': StatCardViewModel(
+                title="% Reach \u22645",
+                value=f"{deep_ft_reach:.1f}%",
+                tooltip="Процент финалок, где Hero дошел до 5 игроков и меньше"
+            ),
+            'deep_ft_stack': StatCardViewModel(
+                title="Stack \u22645",
+                value=StatCardViewModel.format_number(deep_ft_stack_chips, decimals=0),
+                subtitle=f"{StatCardViewModel.format_number(deep_ft_stack_chips, decimals=0)} фишек / {deep_ft_stack_bb:.1f} BB",
+                tooltip="Средний стек при \u22645 игроках на финальном столе"
+            ),
+            'deep_ft_roi': StatCardViewModel(
+                title="ROI \u22645",
+                value=StatCardViewModel.format_percentage(deep_ft_roi),
+                value_color=StatCardViewModel.get_value_color(deep_ft_roi),
+                tooltip="ROI в турнирах, где Hero дошел до стадии \u22645 игроков"
             ),
         }
         


### PR DESCRIPTION
## Summary
- добавлен плагин `DeepFTStat`
- добавлены карточки %Reach<=5, Stack<=5, ROI<=5 в stats grid
- подкраска ROI зависит от знака

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ab2b496ac8323a090f60bf3960ec1