### PR TITLE
Enhance DB label and simplify deep FT stack card

### DIFF
--- a/stats/deep_ft_stat.py
+++ b/stats/deep_ft_stat.py
@@ -29,7 +29,10 @@ class DeepFTStat(BaseStat):
         tournaments = tournaments or []
         final_table_hands = final_table_hands or []
 
-        # Сохраняем первую руку, где игроков 5 или меньше
+        # Сохраняем первую руку, где игроков 5 или меньше.
+        # Это обеспечивает, что стек берется в момент, когда Hero
+        # впервые попадает в стадию \u22645 игроков, независимо от
+        # того, сколько игроков было до этого перехода.
         first_hands: dict[str, FinalTableHand] = {}
         for hand in final_table_hands:
             if hand.players_count <= 5:

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -10,7 +10,8 @@ from .stats_grid import StatsGrid
 from .tournament_view import TournamentView
 from .session_view import SessionView
 from .session_select_dialog import SessionSelectDialog
-from .app_style import apply_dark_theme # Удобно импортировать напрямую для использования в app.py
+from .app_style import apply_dark_theme  # Удобно импортировать напрямую для использования в app.py
+from .gradient_label import GradientLabel
 
 # Добавляй свои компоненты, если будут новые
 
@@ -21,4 +22,5 @@ __all__ = [
     'SessionView',
     'SessionSelectDialog',
     'apply_dark_theme',
+    'GradientLabel',
 ]

--- a/ui/gradient_label.py
+++ b/ui/gradient_label.py
@@ -1,0 +1,29 @@
+from PyQt6 import QtWidgets, QtGui, QtCore
+
+class GradientLabel(QtWidgets.QLabel):
+    """QLabel с поддержкой градиентного текста."""
+
+    def __init__(self, text: str = "", parent: QtWidgets.QWidget | None = None):
+        super().__init__(text, parent)
+        self.colors = [QtGui.QColor("#FFD700"), QtGui.QColor("#FFA500")]
+
+    def setColors(self, colors: list[str]) -> None:
+        """Устанавливает цвета градиента."""
+        self.colors = [QtGui.QColor(c) for c in colors]
+        self.update()
+
+    def paintEvent(self, event: QtGui.QPaintEvent) -> None:
+        # Рисуем текст с градиентом
+        painter = QtGui.QPainter(self)
+        gradient = QtGui.QLinearGradient(0, 0, self.width(), 0)
+        if len(self.colors) == 1:
+            gradient.setColorAt(0, self.colors[0])
+            gradient.setColorAt(1, self.colors[0])
+        else:
+            step = 1 / (len(self.colors) - 1)
+            for i, color in enumerate(self.colors):
+                gradient.setColorAt(i * step, color)
+        painter.setPen(QtGui.QPen(QtGui.QBrush(gradient), 0))
+        painter.setFont(self.font())
+        painter.drawText(self.rect(), int(self.alignment() or QtCore.Qt.AlignmentFlag.AlignLeft | QtCore.Qt.AlignmentFlag.AlignVCenter), self.text())
+

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -25,6 +25,7 @@ from ui.session_select_dialog import SessionSelectDialog
 from ui.custom_icons import CustomIcons  # Импортируем кастомные иконки
 from ui.background import thread_manager
 from models import OverallStats
+from ui.gradient_label import GradientLabel
 
 # Импортируем диалог управления БД
 from ui.database_management_dialog import DatabaseManagementDialog # Предполагаем, что такой файл будет создан
@@ -90,8 +91,11 @@ class MainWindow(QtWidgets.QMainWindow):
         self.statusBar().setSizeGripEnabled(False)
 
         # Метка с информацией о текущей БД (будет размещена в тулбаре)
-        self.db_status_label = QtWidgets.QLabel("")
-        self.db_status_label.setStyleSheet("color: #777; margin-right: 8px;")
+        # Используем градиентный текст и увеличиваем размер на 50%
+        self.db_status_label = GradientLabel("")
+        self.db_status_label.setStyleSheet(
+            "font-weight: bold; font-size: 150%; margin-right: 8px;"
+        )
 
         # Панель инструментов
         self.toolbar = self.addToolBar("Панель инструментов")

--- a/ui/stats_grid.py
+++ b/ui/stats_grid.py
@@ -374,7 +374,7 @@ class StatsGrid(QtWidgets.QWidget):
             'ko_stage_4_5': SpecialStatCard("KO 4-5 игроков", "-"),
             'ko_stage_6_9': StatCard("KO 6-9 игроков", "-"),
             'deep_ft_reach': StatCard("% Проход <=5", "-"),
-            'deep_ft_stack': SpecialStatCard("Стек при <=5", "-"),
+            'deep_ft_stack': StatCard("Стек при <=5", "-"),
             'deep_ft_roi': StatCard("ROI <=5", "-"),
         }
         

--- a/viewmodels/stats_grid.py
+++ b/viewmodels/stats_grid.py
@@ -291,8 +291,7 @@ class StatsGridViewModel:
             ),
             'deep_ft_stack': StatCardViewModel(
                 title="Stack \u22645",
-                value=StatCardViewModel.format_number(deep_ft_stack_chips, decimals=0),
-                subtitle=f"{StatCardViewModel.format_number(deep_ft_stack_chips, decimals=0)} фишек / {deep_ft_stack_bb:.1f} BB",
+                value=f"{StatCardViewModel.format_number(deep_ft_stack_chips, decimals=0)} фишек / {deep_ft_stack_bb:.1f} BB",
                 tooltip="Средний стек при \u22645 игроках на финальном столе"
             ),
             'deep_ft_roi': StatCardViewModel(


### PR DESCRIPTION
## Summary
- show DB label with gradient text
- make `Stack <=5` stat card single line
- clarify deep FT stack calculation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ab7ca26fc8323b81480e5154ab341