### PR TITLE
Improve tournament batch save

### DIFF
--- a/db/repositories/tournament_repo.py
+++ b/db/repositories/tournament_repo.py
@@ -171,6 +171,31 @@ class TournamentRepository:
             return Tournament.from_dict(dict(result[0]))
         return None
 
+    def get_tournaments_by_ids(self, ids: List[str]) -> Dict[str, Tournament]:
+        """Возвращает словарь {tournament_id: Tournament} по списку ID."""
+        if not ids:
+            return {}
+
+        placeholders = ",".join("?" * len(ids))
+        query = f"""
+            SELECT
+                id, tournament_id, tournament_name, start_time, buyin, payout,
+                finish_place, ko_count, session_id, has_ts, has_hh,
+                reached_final_table, final_table_initial_stack_chips,
+                final_table_initial_stack_bb, final_table_start_players
+            FROM tournaments
+            WHERE tournament_id IN ({placeholders})
+        """
+
+        results = self.db.execute_query(query, ids)
+
+        tournaments: Dict[str, Tournament] = {}
+        for row in results:
+            tournament = Tournament.from_dict(dict(row))
+            tournaments[tournament.tournament_id] = tournament
+
+        return tournaments
+
     def get_all_tournaments(
         self,
         session_id: Optional[str] = None,

--- a/services/import_service.py
+++ b/services/import_service.py
@@ -666,9 +666,13 @@ class ImportService:
         updated_ids: List[str] = []
         tournaments_to_save: List[Tournament] = []
 
+        existing_tournaments = self.tournament_repo.get_tournaments_by_ids(
+            list(parsed_tournaments_data.keys())
+        )
+
         for tourney_id, data in parsed_tournaments_data.items():
             try:
-                existing_tourney = self.tournament_repo.get_tournament_by_id(tourney_id)
+                existing_tourney = existing_tournaments.get(tourney_id)
 
                 final_tourney_data: Dict[str, Any] = {}
                 if existing_tourney:


### PR DESCRIPTION
## Summary
- add new `get_tournaments_by_ids` method to `TournamentRepository`
- optimize `_save_tournaments` in `ImportService` to fetch existing tournaments once

## Testing
- `python -m py_compile db/repositories/tournament_repo.py services/import_service.py`

------
https://chatgpt.com/codex/tasks/task_e_684be8772ce883239067a9f8ff5362d0