### PR TITLE
Use ProcessPoolExecutor in ImportService

### DIFF
--- a/services/import_service.py
+++ b/services/import_service.py
@@ -9,8 +9,7 @@
 import os
 import logging
 from typing import List, Dict, Any, Optional, Callable, TYPE_CHECKING
-from concurrent.futures import ThreadPoolExecutor, as_completed
-import threading
+from concurrent.futures import ProcessPoolExecutor, as_completed
 from datetime import datetime
 
 from models import Tournament, Session, FinalTableHand
@@ -352,15 +351,32 @@ class ImportService:
         
         files_processed = 0
         total_files = len(file_infos)
-        lock = threading.Lock()
 
-        def worker(file_path: str, file_type: str, header_lines: List[str]):
-            if is_canceled_callback and is_canceled_callback():
-                return file_path, False
+        def _read_file(file_path: str, file_type: str):
             try:
                 with open(file_path, 'r', encoding='utf-8', errors='ignore') as f:
                     content = f.read()
-                with lock:
+                return file_path, content, True
+            except Exception as e:
+                logger.error(f"Ошибка обработки файла {file_path}: {e}")
+                return file_path, "", False
+
+        with ProcessPoolExecutor() as executor:
+            futures = {
+                executor.submit(_read_file, fp, ft): (ft, hl)
+                for fp, ft, hl in file_infos
+            }
+
+            for future in as_completed(futures):
+                if is_canceled_callback and is_canceled_callback():
+                    logger.warning("=== ИМПОРТ ОТМЕНЕН при парсинге файлов ===")
+                    executor.shutdown(wait=False, cancel_futures=True)
+                    return None
+
+                file_path, content, success = future.result()
+                file_type, header_lines = futures[future]
+
+                if success:
                     self._parse_single_file(
                         file_path,
                         file_type,
@@ -368,27 +384,8 @@ class ImportService:
                         content,
                         session_id,
                         parsed_tournaments_data,
-                        all_final_table_hands_data
+                        all_final_table_hands_data,
                     )
-                return file_path, True
-            except Exception as e:
-                logger.error(f"Ошибка обработки файла {file_path}: {e}")
-                return file_path, True
-
-        with ThreadPoolExecutor() as executor:
-            futures = {
-                executor.submit(worker, fp, ft, hl): fp
-                for fp, ft, hl in file_infos
-            }
-
-            for future in as_completed(futures):
-                if is_canceled_callback and is_canceled_callback():
-                    logger.warning("=== ИМПОРТ ОТМЕНЕН при парсинге файлов ===")
-                    executor.shutdown(wait=False)
-                    return None
-
-                file_path, processed = future.result()
-                if processed:
                     files_processed += 1
                     file_progress = int((files_processed / total_files) * parsing_weight)
                     if progress_callback:


### PR DESCRIPTION
## Summary
- use `ProcessPoolExecutor` in ImportService
- read files in worker process and parse in main process

## Testing
- `python -m py_compile services/import_service.py`

------
https://chatgpt.com/codex/tasks/task_e_684be83959808323beff9d7a8036d520