### PR TITLE
Fix multiprocessing file read

### DIFF
--- a/services/import_service.py
+++ b/services/import_service.py
@@ -29,6 +29,17 @@ from .events import DataImportedEvent
 logger = logging.getLogger('ROYAL_Stats.ImportService')
 
 
+def _read_file(file_path: str, file_type: str):
+    """Читает файл и возвращает его содержимое."""
+    try:
+        with open(file_path, 'r', encoding='utf-8', errors='ignore') as f:
+            content = f.read()
+        return file_path, content, True
+    except Exception as e:
+        logger.error(f"Ошибка обработки файла {file_path}: {e}")
+        return file_path, "", False
+
+
 class ImportService:
     """
     Сервис для импорта файлов истории рук и сводок турниров.
@@ -353,15 +364,6 @@ class ImportService:
         
         files_processed = 0
         total_files = len(file_infos)
-
-        def _read_file(file_path: str, file_type: str):
-            try:
-                with open(file_path, 'r', encoding='utf-8', errors='ignore') as f:
-                    content = f.read()
-                return file_path, content, True
-            except Exception as e:
-                logger.error(f"Ошибка обработки файла {file_path}: {e}")
-                return file_path, "", False
 
         with ProcessPoolExecutor() as executor:
             futures = {


### PR DESCRIPTION
## Summary
- fix process pool pickle error by moving `_read_file` to module level

## Testing
- `python -m py_compile services/import_service.py`


------
https://chatgpt.com/codex/tasks/task_e_684bea826b108323af57965890583c0f